### PR TITLE
Add analysis_key to stage decorator for CombineGvcfsIntoVds

### DIFF
--- a/src/cpg_seqr_loader/stages.py
+++ b/src/cpg_seqr_loader/stages.py
@@ -30,7 +30,7 @@ from cpg_seqr_loader.jobs.TrainVqsrSnpTranches import train_vqsr_snp_tranches
 SHARD_MANIFEST = 'shard-manifest.txt'
 
 
-@stage.stage(analysis_type='combiner')
+@stage.stage(analysis_type='combiner', analysis_keys=['vds'])
 class CombineGvcfsIntoVds(stage.MultiCohortStage):
     def expected_outputs(self, multicohort: targets.MultiCohort) -> dict[str, Path | str]:
         return {


### PR DESCRIPTION
# Purpose

  - As per title, adds the required `analysis_keys` arg to the stage decorator, this is required when the `expected_outputs` is a dict
  - Without this, it leads to failure: https://batch.hail.populationgenomics.org.au/batches/630937/jobs/1

* Requires bumpversion before merging