### PR TITLE
Add alphagenome var scanner script

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -15,7 +15,7 @@ on:
 permissions: {}
 
 env:
-  VERSION: 0.1.3
+  VERSION: 0.1.4
   IMAGE_NAME: cpg-flow-seqr-loader
   DOCKER_DEV: australia-southeast1-docker.pkg.dev/cpg-common/images-dev
   DOCKER_MAIN: australia-southeast1-docker.pkg.dev/cpg-common/images

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ CPG-Flow workflows are operated entirely by defining input Cohorts (see [here](h
 ```bash
 analysis-runner \
     --skip-repo-checkout \
-    --image australia-southeast1-docker.pkg.dev/cpg-common/images/cpg-flow-seqr-loader:0.1.3 \
+    --image australia-southeast1-docker.pkg.dev/cpg-common/images/cpg-flow-seqr-loader:0.1.4 \
     --config src/cpg_seqr_loader/config_template.toml \
     --config cohorts.toml \  # containing the inputs_cohorts and sequencing_type
     --dataset seqr \
@@ -70,7 +70,7 @@ analysis-runner \
 ```bash
 analysis-runner \
     --skip-repo-checkout \
-    --image australia-southeast1-docker.pkg.dev/cpg-common/images/cpg-flow-seqr-loader:0.1.3 \
+    --image australia-southeast1-docker.pkg.dev/cpg-common/images/cpg-flow-seqr-loader:0.1.4 \
     --config src/cpg_seqr_loader/config_template.toml \
     --config cohorts.toml \  # containing the inputs_cohorts and sequencing_type
     --dataset seqr \

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ description='Seqr-Loader (gVCF-combiner) implemented in CPG-Flow'
 readme = "README.md"
 # currently cpg-flow is pinned to this version
 requires-python = ">=3.10,<3.11"
-version="0.1.3"
+version="0.1.4"
 license={"file" = "LICENSE"}
 classifiers=[
     'Environment :: Console',
@@ -122,7 +122,7 @@ hail = ["hail"]
 "src/cpg_seqr_loader/scripts/annotate_cohort.py" = ["E501"]
 
 [tool.bumpversion]
-current_version = "0.1.3"
+current_version = "0.1.4"
 parse = "(?P<major>\\d+)\\.(?P<minor>\\d+)\\.(?P<patch>\\d+)"
 serialize = ["{major}.{minor}.{patch}"]
 commit = true

--- a/src/cpg_seqr_loader/stages.py
+++ b/src/cpg_seqr_loader/stages.py
@@ -109,7 +109,7 @@ class CreateDenseMtFromVdsWithHail(stage.MultiCohortStage):
         outputs = self.expected_outputs(multicohort)
 
         job = generate_densify_jobs(
-            input_vds=inputs.as_str(multicohort, CombineGvcfsIntoVds),
+            input_vds=inputs.as_str(multicohort, CombineGvcfsIntoVds, 'vds'),
             output_mt=outputs['mt'],
             output_sites_only=outputs['hps_vcf_dir'],
             output_separate_header=outputs['separate_header_vcf_dir'],


### PR DESCRIPTION
# Purpose

  - Implements the AlphaGenome variant expression scanner script.
  - Enables scanning and summarizing predicted expression effects of genetic variants across organs.

## Proposed Changes

  - Adds a configurable and stable script for variant effect scanning using the AlphaGenome model.
  - Supports both local and GCS file paths, configurable parameters, and optional result plotting.


