### PR TITLE
Revert to elasticsearch 8.x

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -15,7 +15,7 @@ on:
 permissions: {}
 
 env:
-  VERSION: 0.1.5
+  VERSION: 0.1.6
   IMAGE_NAME: cpg-flow-seqr-loader
   DOCKER_DEV: australia-southeast1-docker.pkg.dev/cpg-common/images-dev
   DOCKER_MAIN: australia-southeast1-docker.pkg.dev/cpg-common/images

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ CPG-Flow workflows are operated entirely by defining input Cohorts (see [here](h
 ```bash
 analysis-runner \
     --skip-repo-checkout \
-    --image australia-southeast1-docker.pkg.dev/cpg-common/images/cpg-flow-seqr-loader:0.1.5 \
+    --image australia-southeast1-docker.pkg.dev/cpg-common/images/cpg-flow-seqr-loader:0.1.6 \
     --config src/cpg_seqr_loader/config_template.toml \
     --config cohorts.toml \  # containing the inputs_cohorts and sequencing_type
     --dataset seqr \
@@ -70,7 +70,7 @@ analysis-runner \
 ```bash
 analysis-runner \
     --skip-repo-checkout \
-    --image australia-southeast1-docker.pkg.dev/cpg-common/images/cpg-flow-seqr-loader:0.1.5 \
+    --image australia-southeast1-docker.pkg.dev/cpg-common/images/cpg-flow-seqr-loader:0.1.6 \
     --config src/cpg_seqr_loader/config_template.toml \
     --config cohorts.toml \  # containing the inputs_cohorts and sequencing_type
     --dataset seqr \

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ classifiers=[
 
 dependencies=[
     'cpg-flow',
-    'elasticsearch',
+    'elasticsearch==8.*',
     'hatchling',
     'loguru',
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ description='Seqr-Loader (gVCF-combiner) implemented in CPG-Flow'
 readme = "README.md"
 # currently cpg-flow is pinned to this version
 requires-python = ">=3.10,<3.11"
-version="0.1.5"
+version="0.1.6"
 license={"file" = "LICENSE"}
 classifiers=[
     'Environment :: Console',
@@ -122,7 +122,7 @@ hail = ["hail"]
 "src/cpg_seqr_loader/scripts/annotate_cohort.py" = ["E501"]
 
 [tool.bumpversion]
-current_version = "0.1.5"
+current_version = "0.1.6"
 parse = "(?P<major>\\d+)\\.(?P<minor>\\d+)\\.(?P<patch>\\d+)"
 serialize = ["{major}.{minor}.{patch}"]
 commit = true


### PR DESCRIPTION
# Purpose

  - Update the pyproject dependencies to install elasticsearch 8.x instead of 9.x, for compatibility with our pre-existing v8 elasticsearch cluster

# Reason

  - Elastic exports are failing with a 400 error. See: https://batch.hail.populationgenomics.org.au/batches/631199/jobs/1
  - Our Elasticsearch cluster is on v8.6, while the package installed is v9 (see [Docker](https://github.com/populationgenomics/cpg-flow-seqr-loader/actions/runs/16823475175/job/47654829379) Github action logs)
  - According to the Elasticsearch [docs](https://pypi.org/project/elasticsearch/), the client (elasticsearch package) version must have the same major version as the cluster itself 