### PR TITLE
Update the image tags in example config

### DIFF
--- a/src/cpg_seqr_loader/config_template.toml
+++ b/src/cpg_seqr_loader/config_template.toml
@@ -66,7 +66,7 @@ snps_recal_disc_size = 20
 snps_gather_disc_size = 10
 
 [images]
-bcftools = "australia-southeast1-docker.pkg.dev/cpg-common/images/bcftools:1.20-2"
+bcftools = "australia-southeast1-docker.pkg.dev/cpg-common/images/bcftools:1.22-1"
 gatk = "australia-southeast1-docker.pkg.dev/cpg-common/images/gatk:4.6.2.0-1"
 vep = "australia-southeast1-docker.pkg.dev/cpg-common/images/vep:110.1-1"
 


### PR DESCRIPTION
# Purpose

  - Updates the default image paths in the embedded TOML to be the latest CPG image-tag structure

## Proposed Changes

  - BCFtools and VEP will be the same version, GATK is a slightly upgraded version.

## Checklist

- [ ] Related GitHub Issue created
- [ ] Tests covering new change
- [x] Linting checks pass
