### PR TITLE
Pin cpg-flow version, add workflow_dispatch for docker rebuild in main

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -76,7 +76,9 @@ jobs:
   docker-prod:
     name: Build & Push to Prod
     runs-on: ubuntu-latest
-    if: github.event_name == 'push' && github.ref_name == 'main'
+    if: |
+      (github.event_name == 'push' && github.ref_name == 'main') ||
+      (github.event_name == 'workflow_dispatch' && github.ref_name == 'main')
     environment: production
     permissions:
       id-token: write

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ classifiers=[
 ]
 
 dependencies=[
-    'cpg-flow>=1',
+    'cpg-flow~=1.1.1',
     'elasticsearch==8.*',
 ]
 


### PR DESCRIPTION
# Purpose

  - We need to rebuild our CPG flow packages because a new version of CPG flow has been released (v1.1.1) with changes we need
  - At present, the workflow dispatch cannot be used to build a new image in prod. The job is automatically skipped even when manually triggered (see [attempt](https://github.com/populationgenomics/cpg-flow-align-genotype/actions/runs/19877334308) in github actions)

This change allows manually triggering a rebuild of the prod image from the main branch. 

Also soft-pins the CPG-Flow version to the latest, v1.1.1