### PR TITLE
Rethink densification

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,8 +19,8 @@ repos:
     # Ruff version.
     rev: v0.11.11
     hooks:
-      - id: ruff
       - id: ruff-format
+      - id: ruff
 
   # Static type analysis (as much as it's possible in python using type hints)
   - repo: https://github.com/pre-commit/mirrors-mypy

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM australia-southeast1-docker.pkg.dev/cpg-common/images/cpg_hail_gcloud:0.2.137.cpg1-2
 
 ENV PYTHONDONTWRITEBYTECODE=1
-ENV VERSION=0.1.18
+ENV VERSION=0.1.19
 
 WORKDIR /cpg_seqr_loader
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM australia-southeast1-docker.pkg.dev/cpg-common/images/cpg_hail_gcloud:0.2.137.cpg1-2
 
 ENV PYTHONDONTWRITEBYTECODE=1
-ENV VERSION=0.1.17
+ENV VERSION=0.1.18
 
 WORKDIR /cpg_seqr_loader
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM australia-southeast1-docker.pkg.dev/cpg-common/images/cpg_hail_gcloud:0.2.137.cpg1-2
 
 ENV PYTHONDONTWRITEBYTECODE=1
-ENV VERSION=0.1.19
+ENV VERSION=0.1.20
 
 WORKDIR /cpg_seqr_loader
 

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ CPG-Flow workflows are operated entirely by defining input Cohorts (see [here](h
 ```bash
 analysis-runner \
     --skip-repo-checkout \
-    --image australia-southeast1-docker.pkg.dev/cpg-common/images/cpg-flow-seqr-loader:0.1.18 \
+    --image australia-southeast1-docker.pkg.dev/cpg-common/images/cpg-flow-seqr-loader:0.1.19 \
     --config src/cpg_seqr_loader/config_template.toml \
     --config cohorts.toml \  # containing the inputs_cohorts and sequencing_type
     --dataset seqr \
@@ -70,7 +70,7 @@ analysis-runner \
 ```bash
 analysis-runner \
     --skip-repo-checkout \
-    --image australia-southeast1-docker.pkg.dev/cpg-common/images/cpg-flow-seqr-loader:0.1.18 \
+    --image australia-southeast1-docker.pkg.dev/cpg-common/images/cpg-flow-seqr-loader:0.1.19 \
     --config src/cpg_seqr_loader/config_template.toml \
     --config cohorts.toml \  # containing the inputs_cohorts and sequencing_type
     --dataset seqr \

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ CPG-Flow workflows are operated entirely by defining input Cohorts (see [here](h
 ```bash
 analysis-runner \
     --skip-repo-checkout \
-    --image australia-southeast1-docker.pkg.dev/cpg-common/images/cpg-flow-seqr-loader:0.1.19 \
+    --image australia-southeast1-docker.pkg.dev/cpg-common/images/cpg-flow-seqr-loader:0.1.19-1 \
     --config src/cpg_seqr_loader/config_template.toml \
     --config cohorts.toml \  # containing the inputs_cohorts and sequencing_type
     --dataset seqr \
@@ -70,7 +70,7 @@ analysis-runner \
 ```bash
 analysis-runner \
     --skip-repo-checkout \
-    --image australia-southeast1-docker.pkg.dev/cpg-common/images/cpg-flow-seqr-loader:0.1.19 \
+    --image australia-southeast1-docker.pkg.dev/cpg-common/images/cpg-flow-seqr-loader:0.1.19-1 \
     --config src/cpg_seqr_loader/config_template.toml \
     --config cohorts.toml \  # containing the inputs_cohorts and sequencing_type
     --dataset seqr \

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ CPG-Flow workflows are operated entirely by defining input Cohorts (see [here](h
 ```bash
 analysis-runner \
     --skip-repo-checkout \
-    --image australia-southeast1-docker.pkg.dev/cpg-common/images/cpg-flow-seqr-loader:0.1.17 \
+    --image australia-southeast1-docker.pkg.dev/cpg-common/images/cpg-flow-seqr-loader:0.1.18 \
     --config src/cpg_seqr_loader/config_template.toml \
     --config cohorts.toml \  # containing the inputs_cohorts and sequencing_type
     --dataset seqr \
@@ -70,7 +70,7 @@ analysis-runner \
 ```bash
 analysis-runner \
     --skip-repo-checkout \
-    --image australia-southeast1-docker.pkg.dev/cpg-common/images/cpg-flow-seqr-loader:0.1.17 \
+    --image australia-southeast1-docker.pkg.dev/cpg-common/images/cpg-flow-seqr-loader:0.1.18 \
     --config src/cpg_seqr_loader/config_template.toml \
     --config cohorts.toml \  # containing the inputs_cohorts and sequencing_type
     --dataset seqr \

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ CPG-Flow workflows are operated entirely by defining input Cohorts (see [here](h
 ```bash
 analysis-runner \
     --skip-repo-checkout \
-    --image australia-southeast1-docker.pkg.dev/cpg-common/images/cpg-flow-seqr-loader:0.1.19-1 \
+    --image australia-southeast1-docker.pkg.dev/cpg-common/images/cpg-flow-seqr-loader:0.1.20-1 \
     --config src/cpg_seqr_loader/config_template.toml \
     --config cohorts.toml \  # containing the inputs_cohorts and sequencing_type
     --dataset seqr \
@@ -70,7 +70,7 @@ analysis-runner \
 ```bash
 analysis-runner \
     --skip-repo-checkout \
-    --image australia-southeast1-docker.pkg.dev/cpg-common/images/cpg-flow-seqr-loader:0.1.19-1 \
+    --image australia-southeast1-docker.pkg.dev/cpg-common/images/cpg-flow-seqr-loader:0.1.20-1 \
     --config src/cpg_seqr_loader/config_template.toml \
     --config cohorts.toml \  # containing the inputs_cohorts and sequencing_type
     --dataset seqr \

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ description='Seqr-Loader (gVCF-combiner) implemented in CPG-Flow'
 readme = "README.md"
 # currently cpg-flow is pinned to this version
 requires-python = ">=3.10,<3.12"
-version="0.1.17"
+version="0.1.18"
 license={"file" = "LICENSE"}
 classifiers=[
     'Environment :: Console',
@@ -120,7 +120,7 @@ hail = ["hail"]
 "src/cpg_seqr_loader/scripts/annotate_cohort.py" = ["E501"]
 
 [tool.bumpversion]
-current_version = "0.1.17"
+current_version = "0.1.18"
 parse = "(?P<major>\\d+)\\.(?P<minor>\\d+)\\.(?P<patch>\\d+)"
 serialize = ["{major}.{minor}.{patch}"]
 commit = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ description='Seqr-Loader (gVCF-combiner) implemented in CPG-Flow'
 readme = "README.md"
 # currently cpg-flow is pinned to this version
 requires-python = ">=3.10,<3.12"
-version="0.1.19"
+version="0.1.20"
 license={"file" = "LICENSE"}
 classifiers=[
     'Environment :: Console',
@@ -120,7 +120,7 @@ hail = ["hail"]
 "src/cpg_seqr_loader/scripts/annotate_cohort.py" = ["E501"]
 
 [tool.bumpversion]
-current_version = "0.1.19"
+current_version = "0.1.20"
 parse = "(?P<major>\\d+)\\.(?P<minor>\\d+)\\.(?P<patch>\\d+)"
 serialize = ["{major}.{minor}.{patch}"]
 commit = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ description='Seqr-Loader (gVCF-combiner) implemented in CPG-Flow'
 readme = "README.md"
 # currently cpg-flow is pinned to this version
 requires-python = ">=3.10,<3.12"
-version="0.1.18"
+version="0.1.19"
 license={"file" = "LICENSE"}
 classifiers=[
     'Environment :: Console',
@@ -120,7 +120,7 @@ hail = ["hail"]
 "src/cpg_seqr_loader/scripts/annotate_cohort.py" = ["E501"]
 
 [tool.bumpversion]
-current_version = "0.1.18"
+current_version = "0.1.19"
 parse = "(?P<major>\\d+)\\.(?P<minor>\\d+)\\.(?P<patch>\\d+)"
 serialize = ["{major}.{minor}.{patch}"]
 commit = true

--- a/src/cpg_seqr_loader/scripts/annotate_cohort.py
+++ b/src/cpg_seqr_loader/scripts/annotate_cohort.py
@@ -241,7 +241,7 @@ def annotate_cohort(
     if avi_table := config.config_retrieve(['references', 'avi_table'], None):
         refavis_ht = hl.read_table(avi_table)
         loguru.logger.info('Annotating with refavis data')
-        mt = mt.annotate_rows(avis=(refavis_ht[mt.row_key].normalised_avis,))
+        mt = mt.annotate_rows(avis=(refavis_ht[mt.row_key].normalised_avis))
 
     # annotate all the gnomAD v4 fields in a separate function
     mt = annotate_gnomad4(mt)

--- a/src/cpg_seqr_loader/scripts/annotate_cohort.py
+++ b/src/cpg_seqr_loader/scripts/annotate_cohort.py
@@ -242,7 +242,6 @@ def annotate_cohort(
         refavis_ht = hl.read_table(avi_table)
         loguru.logger.info('Annotating with refavis data')
         mt = mt.annotate_rows(avis=(refavis_ht[mt.row_key].normalised_avis,))
-        mt.describe()
 
     # annotate all the gnomAD v4 fields in a separate function
     mt = annotate_gnomad4(mt)
@@ -307,6 +306,7 @@ def annotate_cohort(
         )
 
     loguru.logger.info('Final Structure:')
+    mt.describe(handler=loguru.logger.info)
     mt.write(out_mt_path, overwrite=True)
     loguru.logger.info(f'Written final matrix table into {out_mt_path}')
 

--- a/src/cpg_seqr_loader/scripts/annotate_cohort.py
+++ b/src/cpg_seqr_loader/scripts/annotate_cohort.py
@@ -129,7 +129,7 @@ def annotate_gnomad4(mt: hl.MatrixTable) -> hl.MatrixTable:
     target_xy_index = hl.eval(gnomad4_ht.globals.joint_globals.freq_index_dict[GNOMAD_XY_TARGET_POP])
 
     return mt.annotate_rows(
-        gnomad_genomes=hl.struct(
+        gnomad_joint=hl.struct(
             # these are taken explicitly from the adj population (across all of gnomAD)
             AC=gnomad4_ht[mt.row_key].joint.freq[target_index].AC,
             AN=gnomad4_ht[mt.row_key].joint.freq[target_index].AN,

--- a/src/cpg_seqr_loader/scripts/densify_VDS_to_MT.py
+++ b/src/cpg_seqr_loader/scripts/densify_VDS_to_MT.py
@@ -96,7 +96,12 @@ def main(
                 fill_value=0,
                 number='R',
             ),
-            PL=hl.vds.local_to_global(mt.LPL, mt.AD, number='g', fill_value=999,)
+            PL=hl.vds.local_to_global(
+                mt.LPL,
+                mt.AD,
+                number='g',
+                fill_value=999,
+            ),
         )
 
         mt = mt.drop('gvcf_info')

--- a/src/cpg_seqr_loader/scripts/densify_VDS_to_MT.py
+++ b/src/cpg_seqr_loader/scripts/densify_VDS_to_MT.py
@@ -118,7 +118,6 @@ def main(
 
         # find the minimal representation for each variant
         mt = mt.annotate_rows(minrep=hl.min_rep(mt.locus, mt.alleles))
-        # Struct(locus=Locus(contig=1, position=100002, reference_genome=GRCh37), alleles=['T', 'C'])
 
         # rotate the table key(s)
         mt = mt.key_rows_by(

--- a/src/cpg_seqr_loader/scripts/densify_VDS_to_MT.py
+++ b/src/cpg_seqr_loader/scripts/densify_VDS_to_MT.py
@@ -99,8 +99,9 @@ def main(
             PL=hl.vds.local_to_global(
                 mt.LPL,
                 mt.LA,
-                number='G',
+                n_alleles=hl.len(mt.alleles),
                 fill_value=999,
+                number='G',
             ),
         )
 

--- a/src/cpg_seqr_loader/scripts/densify_VDS_to_MT.py
+++ b/src/cpg_seqr_loader/scripts/densify_VDS_to_MT.py
@@ -116,6 +116,16 @@ def main(
         # adjust the AC field after splitting (not handled in split_multi, see method docstring)
         mt = mt.annotate_rows(info=mt.info.annotate(AC=mt.info.AC[mt.a_index - 1]))
 
+        # find the minimal representation for each variant
+        mt = mt.annotate_rows(minrep=hl.min_rep(mt.locus, mt.alleles))
+        # Struct(locus=Locus(contig=1, position=100002, reference_genome=GRCh37), alleles=['T', 'C'])
+
+        # rotate the table key(s)
+        mt = mt.key_rows_by(
+            locus=mt.minrep.locus,
+            alleles=mt.minrep.alleles,
+        )
+
         loguru.logger.info(f'Writing fresh data into {dense_mt_out}')
         mt.write(dense_mt_out, overwrite=True)
 

--- a/src/cpg_seqr_loader/scripts/densify_VDS_to_MT.py
+++ b/src/cpg_seqr_loader/scripts/densify_VDS_to_MT.py
@@ -98,7 +98,7 @@ def main(
             ),
             PL=hl.vds.local_to_global(
                 mt.LPL,
-                mt.AD,
+                mt.LA,
                 number='g',
                 fill_value=999,
             ),

--- a/src/cpg_seqr_loader/scripts/densify_VDS_to_MT.py
+++ b/src/cpg_seqr_loader/scripts/densify_VDS_to_MT.py
@@ -99,7 +99,7 @@ def main(
             PL=hl.vds.local_to_global(
                 mt.LPL,
                 mt.LA,
-                number='g',
+                number='G',
                 fill_value=999,
             ),
         )

--- a/src/cpg_seqr_loader/scripts/densify_VDS_to_MT.py
+++ b/src/cpg_seqr_loader/scripts/densify_VDS_to_MT.py
@@ -113,6 +113,9 @@ def main(
         # split out multiallelic rows on the dense representation
         mt = hl.split_multi_hts(mt)
 
+        # adjust the AC field after splitting (not handled in split_multi, see method docstring)
+        mt = mt.annotate_rows(info=mt.info.annotate(AC=mt.info.AC[mt.a_index - 1]))
+
         loguru.logger.info(f'Writing fresh data into {dense_mt_out}')
         mt.write(dense_mt_out, overwrite=True)
 

--- a/src/cpg_seqr_loader/scripts/densify_VDS_to_MT.py
+++ b/src/cpg_seqr_loader/scripts/densify_VDS_to_MT.py
@@ -86,14 +86,26 @@ def main(
             pipe_delimited_annotations=[],
         )
 
+        # annotate with densified representations
+        mt = mt.annotate_entries(
+            GT=hl.vds.lgt_to_gt(mt.LGT, mt.LA),
+            AD=hl.vds.local_to_global(
+                mt.LAD,
+                mt.LA,
+                n_alleles=hl.len(mt.alleles),
+                fill_value=0,
+                number='R',
+            ),
+            PL=hl.vds.local_to_global(mt.LPL, mt.AD, number='g', fill_value=999,)
+        )
+
+        mt = mt.drop('gvcf_info')
+
         # annotate this info back into the main MatrixTable
         mt = mt.annotate_rows(info=info_ht[mt.row_key].info)
 
-        # unpack mt.info.info back into mt.info. Must be better syntax for this?
-        mt = mt.drop('gvcf_info')
-
-        loguru.logger.info('Splitting multiallelics, in a sparse way')
-        mt = hl.experimental.sparse_split_multi(mt)
+        # split out multiallelic rows on the dense representation
+        mt = hl.split_multi_hts(mt)
 
         loguru.logger.info(f'Writing fresh data into {dense_mt_out}')
         mt.write(dense_mt_out, overwrite=True)

--- a/src/cpg_seqr_loader/stages.py
+++ b/src/cpg_seqr_loader/stages.py
@@ -385,6 +385,7 @@ class AnnotateVcfsWithVep(stage.MultiCohortStage):
         AnnotateVcfsWithVep,
         RunIndelVqsr,
     ],
+    analysis_type='matrixtable',
 )
 class AnnotateCohort(stage.MultiCohortStage):
     """


### PR DESCRIPTION
# Purpose

  - VDS -> MT densification is currently pretty rubbish

## Issues

This process walks a dataset from sparse VDS to dense MT in a few steps. Mixed in is the use of `default_compute_info`, which uses the gVCF_info data to generate pseudo-annotations, as if the data were freshly joint called. 

  - The original implementation here _worked_, but not well. It delegates most of the local-to-global attribute changes to `hl.experimental`, which doesn't correctly update all the fields. E.g. PL might currently be wrongly formatted in our MatrixTables
  - There are a couple of blessed Hail methods `hl.vds.local_to_global` and `hl.vds.lgt_to_gt` which should have been used, but I wasn't aware of them at the time
  - We split multiallelic variants out onto separate rows, but because not all annotations were correctly swapped from global to local (e.g. LPL instead of PL), this was done using `hl.experimental.sparse_split_multi(mt)`, which doesn't split all fields correctly. 

## Re-Write

This process has been redrafted to include a few changes

  - initial densification is unchanged, with the gvcf info fields still generated and annotated in as before
  - LGT, LPL, and LAD fields are all decoded to the global annotation using specific methods, including `mt.LA` to decode the fields.
  - After the entries are updated, the MT is split using the proper method, which should result in accurate splitting of all relevant fields (GT, AD, PL) into separate variants in the final MT. 

## Testing

I've tested the syntax on some PopGen test VDS-format data, but that data did not include multiallelic variants. It would be good to run this in test on some VDS data

## Checklist

- [x] Version Bump!
- [ ] Related GitHub Issue created
- [ ] Tests covering new change
- [ ] Linting checks pass

---

Other issues from hail source code/docstring
**VCF Info Fields**

Hail does not split fields in the info field. This means that if a
multiallelic site with `info.AC` value ``[10, 2]`` is split, each split
site will contain the same array ``[10, 2]``. The provided allele index
field `a_index` can be used to select the value corresponding to the split
allele's position:

```
>>> split_ds = hl.split_multi_hts(dataset)
>>> split_ds = split_ds.filter_rows(split_ds.info.AC[split_ds.a_index - 1] < 10, keep = False)
```

solution = reduce the AC value back down to 1 in the final output
```
>>> split_ds = hl.split_multi_hts(dataset)
>>> split_ds = split_ds.annotate_rows(info = split_ds.info.annotate(AC = split_ds.info.AC[split_ds.a_index - 1]))
>>> hl.export_vcf(split_ds, 'output/export.vcf')
```

At this stage we should also run a minrep call post splitting, to normalise the ref and alt alleles. This will aid in annotation with downstream resources (VEP, AVI, etc.)
https://hail.is/docs/0.2/functions/genetics.html#hail.expr.functions.min_rep

* what happens if/when a non-normalised variant is normalised? Do we end up with 2 competing variants with the same minimally represented CHR-POS-REF-ALT? 
* If we do end up with doubles in the dataset, does each have variant calls attributed to different samples?