### PR TITLE
Add option for naive coalesce partitions during densify VDS

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM australia-southeast1-docker.pkg.dev/cpg-common/images/cpg_hail_gcloud:0.2.137.cpg1-2
 
 ENV PYTHONDONTWRITEBYTECODE=1
-ENV VERSION=0.1.20
+ENV VERSION=0.1.21
 
 WORKDIR /cpg_seqr_loader
 

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ CPG-Flow workflows are operated entirely by defining input Cohorts (see [here](h
 ```bash
 analysis-runner \
     --skip-repo-checkout \
-    --image australia-southeast1-docker.pkg.dev/cpg-common/images/cpg-flow-seqr-loader:0.1.20-1 \
+    --image australia-southeast1-docker.pkg.dev/cpg-common/images/cpg-flow-seqr-loader:0.1.21-1 \
     --config src/cpg_seqr_loader/config_template.toml \
     --config cohorts.toml \  # containing the inputs_cohorts and sequencing_type
     --dataset seqr \
@@ -70,7 +70,7 @@ analysis-runner \
 ```bash
 analysis-runner \
     --skip-repo-checkout \
-    --image australia-southeast1-docker.pkg.dev/cpg-common/images/cpg-flow-seqr-loader:0.1.20-1 \
+    --image australia-southeast1-docker.pkg.dev/cpg-common/images/cpg-flow-seqr-loader:0.1.21-1 \
     --config src/cpg_seqr_loader/config_template.toml \
     --config cohorts.toml \  # containing the inputs_cohorts and sequencing_type
     --dataset seqr \

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ description='Seqr-Loader (gVCF-combiner) implemented in CPG-Flow'
 readme = "README.md"
 # currently cpg-flow is pinned to this version
 requires-python = ">=3.10,<3.12"
-version="0.1.20"
+version="0.1.21"
 license={"file" = "LICENSE"}
 classifiers=[
     'Environment :: Console',
@@ -120,7 +120,7 @@ hail = ["hail"]
 "src/cpg_seqr_loader/scripts/annotate_cohort.py" = ["E501"]
 
 [tool.bumpversion]
-current_version = "0.1.20"
+current_version = "0.1.21"
 parse = "(?P<major>\\d+)\\.(?P<minor>\\d+)\\.(?P<patch>\\d+)"
 serialize = ["{major}.{minor}.{patch}"]
 commit = true

--- a/src/cpg_seqr_loader/config_template.toml
+++ b/src/cpg_seqr_loader/config_template.toml
@@ -43,6 +43,12 @@ target_records = 30000
 sg_remove_threshold = 20
 sg_remove_confirm = false
 
+# Number of paritions to use when densifying VDS to MT
+densify_partitions = 1000
+# option to use naive coalesce for densification, which may be less efficient but can bypass
+# some bugs related to Hail calculating partitions based on the VDS
+densify_partitions_naive_coalesce = false
+
 [annotate_dataset]
 # highem, standard, or a string, e.g. "4Gi"
 worker_memory = "highmem"

--- a/src/cpg_seqr_loader/scripts/densify_VDS_to_MT.py
+++ b/src/cpg_seqr_loader/scripts/densify_VDS_to_MT.py
@@ -59,8 +59,9 @@ def main(
 
         # providing n_partitions here gets Hail to calculate the intervals per partition on the VDS var and ref data
         # however there are bugs that can cause this to error out, so we have an option to bypass this
+        # with a naive coalesce instead, which will just combine partitions after the fact
         if config.config_retrieve(['combiner', 'densify_partitions_naive_coalesce'], False):
-            loguru.logger.info('Using naive coalesce for densification, which may be less efficient...')
+            loguru.logger.info('Using naive coalesce for densification')
             vds = hl.vds.read_vds(vds_in)
             mt = hl.vds.to_dense_mt(vds)
             mt = mt.naive_coalesce(partitions)

--- a/src/cpg_seqr_loader/scripts/densify_VDS_to_MT.py
+++ b/src/cpg_seqr_loader/scripts/densify_VDS_to_MT.py
@@ -51,7 +51,7 @@ def main(
         driver_cores=config.config_retrieve(['combiner', 'driver_cores'], 2),
     )
 
-    partitions = config.config_retrieve(['combiner', 'densify_partitions'], 2000)
+    partitions = config.config_retrieve(['combiner', 'densify_partitions'], 1000)
 
     # check here to see if we can reuse the dense MT
     if not utils.can_reuse(dense_mt_out):

--- a/src/cpg_seqr_loader/scripts/densify_VDS_to_MT.py
+++ b/src/cpg_seqr_loader/scripts/densify_VDS_to_MT.py
@@ -51,16 +51,22 @@ def main(
         driver_cores=config.config_retrieve(['combiner', 'driver_cores'], 2),
     )
 
-    partitions = config.config_retrieve(['workflow', 'densify_partitions'], 2000)
+    partitions = config.config_retrieve(['combiner', 'densify_partitions'], 2000)
 
     # check here to see if we can reuse the dense MT
     if not utils.can_reuse(dense_mt_out):
         loguru.logger.info(f'Densifying data, using {partitions} partitions')
 
         # providing n_partitions here gets Hail to calculate the intervals per partition on the VDS var and ref data
-        vds = hl.vds.read_vds(vds_in, n_partitions=partitions)
-
-        mt = hl.vds.to_dense_mt(vds)
+        # however there are bugs that can cause this to error out, so we have an option to bypass this
+        if config.config_retrieve(['combiner', 'densify_partitions_naive_coalesce'], False):
+            loguru.logger.info('Using naive coalesce for densification, which may be less efficient...')
+            vds = hl.vds.read_vds(vds_in)
+            mt = hl.vds.to_dense_mt(vds)
+            mt = mt.naive_coalesce(partitions)
+        else:
+            vds = hl.vds.read_vds(vds_in, n_partitions=partitions)
+            mt = hl.vds.to_dense_mt(vds)
 
         # taken from _filter_rows_and_add_tags in large_cohort/site_only_vcf.py
         # remove any monoallelic or non-ref-in-any-sample sites


### PR DESCRIPTION
# Purpose

  - The densify VDS to MT code is running into issues with partitioning the data, potentially caused by our VDS crossing a threshold number of samples to trigger a bug

## Proposed Changes

  - Add config option to skip passing the partitions to the VDS, and instead pass them to naive coalesce on the dense MT produced from the VDS
  - Also add the config option for the partition count and set the default to 1000

## Checklist

- [ ] Version Bump!
- [ ] Related GitHub Issue created
- [ ] Tests covering new change
- [ ] Linting checks pass
