### PR TITLE
More densification debugging & checkpoint path change

### DIFF
--- a/.github/workflows/dev_auto_build.yaml
+++ b/.github/workflows/dev_auto_build.yaml
@@ -4,7 +4,7 @@ on:
   pull_request:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  group: ${{ github.head_ref }}
   cancel-in-progress: true
 
 permissions:

--- a/.github/workflows/dev_auto_build.yaml
+++ b/.github/workflows/dev_auto_build.yaml
@@ -1,9 +1,11 @@
 name: Autobuild development image
+
 on:
-  push:
-    branches-ignore:
-      - main
-  workflow_dispatch:
+  pull_request:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 
 permissions:
   id-token: write

--- a/.github/workflows/dev_auto_build.yaml
+++ b/.github/workflows/dev_auto_build.yaml
@@ -1,8 +1,8 @@
 name: Autobuild development image
 
-on:
-  pull_request:
+on: [pull_request, workflow_dispatch]
 
+# only build one set of images
 concurrency:
   group: ${{ github.head_ref }}
   cancel-in-progress: true

--- a/.github/workflows/dev_auto_build.yaml
+++ b/.github/workflows/dev_auto_build.yaml
@@ -1,6 +1,6 @@
 name: Autobuild development image
 
-on: [pull_request, workflow_dispatch]
+on: [pull_request]
 
 # only build one set of images
 concurrency:
@@ -23,7 +23,6 @@ jobs:
   get_next_version:
     runs-on: ubuntu-latest
     environment: development
-    if: ${{ github.event_name == 'push' || github.event_name == 'workflow_dispatch' }}
     outputs:
       matrix: ${{ steps.get_next_version.outputs.next_version }}
     steps:
@@ -61,7 +60,7 @@ jobs:
     environment: development
     needs:
       - get_next_version
-    if: ${{ needs.get_next_version.outputs.matrix != '{"include":[]}' && needs.get_next_version.outputs.matrix != '' && github.event_name == 'push' }}
+    if: ${{ needs.get_next_version.outputs.matrix != '{"include":[]}' && needs.get_next_version.outputs.matrix != ''}} && github.event.pull_request.draft == false
     strategy:
       matrix: ${{ fromJson(needs.get_next_version.outputs.matrix) }}
     steps:

--- a/.github/workflows/dev_auto_build.yaml
+++ b/.github/workflows/dev_auto_build.yaml
@@ -4,7 +4,7 @@ on: [pull_request]
 
 # only build one set of images
 concurrency:
-  group: ${{ github.head_ref }}
+  group: ${{ github.workflow }}-${{ github.head_ref }}
   cancel-in-progress: true
 
 permissions:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM australia-southeast1-docker.pkg.dev/cpg-common/images/cpg_hail_gcloud:0.2.138.cpg1-1
 
 ENV PYTHONDONTWRITEBYTECODE=1
-ENV VERSION=0.1.23
+ENV VERSION=0.1.24
 
 WORKDIR /cpg_seqr_loader
 

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ CPG-Flow workflows are operated entirely by defining input Cohorts (see [here](h
 ```bash
 analysis-runner \
     --skip-repo-checkout \
-    --image australia-southeast1-docker.pkg.dev/cpg-common/images/cpg-flow-seqr-loader:0.1.23-1 \
+    --image australia-southeast1-docker.pkg.dev/cpg-common/images/cpg-flow-seqr-loader:0.1.24-1 \
     --config src/cpg_seqr_loader/config_template.toml \
     --config cohorts.toml \  # containing the inputs_cohorts and sequencing_type
     --dataset seqr \
@@ -70,7 +70,7 @@ analysis-runner \
 ```bash
 analysis-runner \
     --skip-repo-checkout \
-    --image australia-southeast1-docker.pkg.dev/cpg-common/images/cpg-flow-seqr-loader:0.1.23-1 \
+    --image australia-southeast1-docker.pkg.dev/cpg-common/images/cpg-flow-seqr-loader:0.1.24-1 \
     --config src/cpg_seqr_loader/config_template.toml \
     --config cohorts.toml \  # containing the inputs_cohorts and sequencing_type
     --dataset seqr \

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ description='Seqr-Loader (gVCF-combiner) implemented in CPG-Flow'
 readme = "README.md"
 # currently cpg-flow is pinned to this version
 requires-python = ">=3.10,<3.12"
-version="0.1.23"
+version="0.1.24"
 license={"file" = "LICENSE"}
 classifiers=[
     'Environment :: Console',
@@ -120,7 +120,7 @@ hail = ["hail"]
 "src/cpg_seqr_loader/scripts/annotate_cohort.py" = ["E501"]
 
 [tool.bumpversion]
-current_version = "0.1.23"
+current_version = "0.1.24"
 parse = "(?P<major>\\d+)\\.(?P<minor>\\d+)\\.(?P<patch>\\d+)"
 serialize = ["{major}.{minor}.{patch}"]
 commit = true

--- a/src/cpg_seqr_loader/scripts/densify_VDS_to_MT.py
+++ b/src/cpg_seqr_loader/scripts/densify_VDS_to_MT.py
@@ -59,7 +59,7 @@ def densify(vds_path: str, partitions: int, checkpoint_path: str) -> hl.MatrixTa
         ANS=hl.agg.count_where(hl.is_defined(mt.LGT)) * 2,
     )
 
-    return mt.checkpoint(checkpoint_path)
+    return mt.checkpoint(checkpoint_path, overwrite=True)
 
 
 def generate_mt_info(mt: hl.MatrixTable) -> hl.MatrixTable:

--- a/src/cpg_seqr_loader/scripts/densify_VDS_to_MT.py
+++ b/src/cpg_seqr_loader/scripts/densify_VDS_to_MT.py
@@ -116,10 +116,10 @@ def split_and_normalise(mt: hl.MatrixTable) -> hl.MatrixTable:
     Runs the multiallelic splitting, and variant representation normalisation process.
 
     Args:
-        mt:
+        mt: MatrixTable
 
     Returns:
-
+        the same MT data, with normalised and minimally-represented variants
     """
 
     # split out multiallelic rows on the dense representation

--- a/src/cpg_seqr_loader/scripts/densify_VDS_to_MT.py
+++ b/src/cpg_seqr_loader/scripts/densify_VDS_to_MT.py
@@ -24,6 +24,120 @@ from cpg_seqr_loader.hail_scripts.sparse_mt import default_compute_info
 from cpg_seqr_loader.hail_scripts.vcf import adjust_vcf_incompatible_types
 
 
+def densify(vds_path: str, partitions: int, checkpoint_path: str) -> hl.MatrixTable:
+    """
+    Segregating the densification logic out here - this method reads in a VDS, densifies, repartitions, and checkpoints
+
+    Args:
+        vds_path: where to find the VDS input (in GCS)
+        partitions: how many partitions to use
+        checkpoint_path: where to write the resulting MT (in GCS)
+
+    Returns:
+        the resulting MatrixTable
+    """
+
+    # providing n_partitions here gets Hail to calculate the intervals per partition on the VDS var and ref data
+    # however there are bugs that can cause this to error out, so we have an option to bypass this
+    # with a naive coalesce instead, which will just combine partitions after the fact
+    if config.config_retrieve(['combiner', 'densify_partitions_naive_coalesce'], False):
+        loguru.logger.info('Using naive coalesce for densification')
+        vds = hl.vds.read_vds(vds_path)
+        mt = hl.vds.to_dense_mt(vds)
+        mt = mt.naive_coalesce(partitions)
+    else:
+        vds = hl.vds.read_vds(vds_path, n_partitions=partitions)
+        mt = hl.vds.to_dense_mt(vds)
+
+    # taken from _filter_rows_and_add_tags in large_cohort/site_only_vcf.py
+    # remove any monoallelic or non-ref-in-any-sample sites
+    mt = mt.filter_rows((hl.len(mt.alleles) > 1) & (hl.agg.any(mt.LGT.is_non_ref())))
+
+    # annotate site-level DP to avoid name collision
+    mt = mt.annotate_rows(
+        site_dp=hl.agg.sum(mt.DP),
+        ANS=hl.agg.count_where(hl.is_defined(mt.LGT)) * 2,
+    )
+
+    return mt.checkpoint(checkpoint_path)
+
+
+def generate_mt_info(mt: hl.MatrixTable) -> hl.MatrixTable:
+    """
+    Applies all the methods to generate GATK-similar INFO attributes on a Combined VDS -> MT.
+
+    Args:
+        mt: MatrixTable
+
+    Returns:
+        annotated MatrixTable
+    """
+    # content shared with large_cohort.site_only_vcf.py
+    info_ht = default_compute_info(mt, site_annotations=True, n_partitions=mt.n_partitions())
+    info_ht = info_ht.annotate(info=info_ht.info.annotate(DP=mt.rows()[info_ht.key].site_dp))
+
+    info_ht = adjust_vcf_incompatible_types(
+        info_ht,
+        # with default INFO_VCF_AS_PIPE_DELIMITED_FIELDS, AS_VarDP will be converted
+        # into a pipe-delimited value e.g.: VarDP=|132.1|140.2
+        # which breaks VQSR parser (it doesn't recognise the delimiter and treats
+        # it as an array with a single string value "|132.1|140.2", leading to
+        # an IndexOutOfBound exception when trying to access value for second allele)
+        pipe_delimited_annotations=[],
+    )
+
+    # annotate with densified representations
+    mt = mt.annotate_entries(
+        GT=hl.vds.lgt_to_gt(mt.LGT, mt.LA),
+        AD=hl.vds.local_to_global(
+            mt.LAD,
+            mt.LA,
+            n_alleles=hl.len(mt.alleles),
+            fill_value=0,
+            number='R',
+        ),
+        PL=hl.vds.local_to_global(
+            mt.LPL,
+            mt.LA,
+            n_alleles=hl.len(mt.alleles),
+            fill_value=999,
+            number='G',
+        ),
+    )
+
+    mt = mt.drop('gvcf_info')
+
+    # annotate this info back into the main MatrixTable
+    return mt.annotate_rows(info=info_ht[mt.row_key].info)
+
+
+def split_and_normalise(mt: hl.MatrixTable) -> hl.MatrixTable:
+    """
+    Runs the multiallelic splitting, and variant representation normalisation process.
+
+    Args:
+        mt:
+
+    Returns:
+
+    """
+
+    # split out multiallelic rows on the dense representation
+    mt = hl.split_multi_hts(mt)
+
+    # adjust the AC field after splitting (not handled in split_multi, see method docstring)
+    mt = mt.annotate_rows(info=mt.info.annotate(AC=mt.info.AC[mt.a_index - 1]))
+
+    # find the minimal representation for each variant
+    mt = mt.annotate_rows(minrep=hl.min_rep(mt.locus, mt.alleles))
+
+    # rotate the table key(s)
+    return mt.key_rows_by(
+        locus=mt.minrep.locus,
+        alleles=mt.minrep.alleles,
+    )
+
+
 def main(
     vds_in: str,
     dense_mt_out: str,
@@ -41,6 +155,7 @@ def main(
     Args:
         vds_in (str):
         dense_mt_out (str):
+        checkpoint_path (str): path to save/resume from a checkpoint MT post densification
         sites_only (str): optional, if used write a sites-only VCF directory to this location
         separate_header (str): optional, write a sites-only VCF directory with a separate header to this location
     """
@@ -58,82 +173,20 @@ def main(
     if not utils.can_reuse(dense_mt_out):
         loguru.logger.info(f'Densifying data, using {partitions} partitions')
 
-        # providing n_partitions here gets Hail to calculate the intervals per partition on the VDS var and ref data
-        # however there are bugs that can cause this to error out, so we have an option to bypass this
-        # with a naive coalesce instead, which will just combine partitions after the fact
-        if config.config_retrieve(['combiner', 'densify_partitions_naive_coalesce'], False):
-            loguru.logger.info('Using naive coalesce for densification')
-            vds = hl.vds.read_vds(vds_in)
-            mt = hl.vds.to_dense_mt(vds)
-            mt = mt.naive_coalesce(partitions)
+        # and check here to see if we can re-use the checkpoint
+        if utils.can_reuse(checkpoint_path):
+            loguru.logger.info(f'Resuming from a densified checkpoint: {checkpoint_path}')
+            mt = hl.read_matrix_table(checkpoint_path)
+
         else:
-            vds = hl.vds.read_vds(vds_in, n_partitions=partitions)
-            mt = hl.vds.to_dense_mt(vds)
+            loguru.logger.info(f'Running a VDS -> with densification, checkpointing to {checkpoint_path}')
+            mt = densify(vds_in, partitions, checkpoint_path)
 
-        # taken from _filter_rows_and_add_tags in large_cohort/site_only_vcf.py
-        # remove any monoallelic or non-ref-in-any-sample sites
-        mt = mt.filter_rows((hl.len(mt.alleles) > 1) & (hl.agg.any(mt.LGT.is_non_ref())))
+        # run the INFO field generation/annotation process
+        mt = generate_mt_info(mt)
 
-        # annotate site-level DP to avoid name collision
-        mt = mt.annotate_rows(
-            site_dp=hl.agg.sum(mt.DP),
-            ANS=hl.agg.count_where(hl.is_defined(mt.LGT)) * 2,
-        )
-
-        mt = mt.checkpoint(checkpoint_path, _read_if_exists=True)
-
-        # content shared with large_cohort.site_only_vcf.py
-        info_ht = default_compute_info(mt, site_annotations=True, n_partitions=mt.n_partitions())
-        info_ht = info_ht.annotate(info=info_ht.info.annotate(DP=mt.rows()[info_ht.key].site_dp))
-
-        info_ht = adjust_vcf_incompatible_types(
-            info_ht,
-            # with default INFO_VCF_AS_PIPE_DELIMITED_FIELDS, AS_VarDP will be converted
-            # into a pipe-delimited value e.g.: VarDP=|132.1|140.2
-            # which breaks VQSR parser (it doesn't recognise the delimiter and treats
-            # it as an array with a single string value "|132.1|140.2", leading to
-            # an IndexOutOfBound exception when trying to access value for second allele)
-            pipe_delimited_annotations=[],
-        )
-
-        # annotate with densified representations
-        mt = mt.annotate_entries(
-            GT=hl.vds.lgt_to_gt(mt.LGT, mt.LA),
-            AD=hl.vds.local_to_global(
-                mt.LAD,
-                mt.LA,
-                n_alleles=hl.len(mt.alleles),
-                fill_value=0,
-                number='R',
-            ),
-            PL=hl.vds.local_to_global(
-                mt.LPL,
-                mt.LA,
-                n_alleles=hl.len(mt.alleles),
-                fill_value=999,
-                number='G',
-            ),
-        )
-
-        mt = mt.drop('gvcf_info')
-
-        # annotate this info back into the main MatrixTable
-        mt = mt.annotate_rows(info=info_ht[mt.row_key].info)
-
-        # split out multiallelic rows on the dense representation
-        mt = hl.split_multi_hts(mt)
-
-        # adjust the AC field after splitting (not handled in split_multi, see method docstring)
-        mt = mt.annotate_rows(info=mt.info.annotate(AC=mt.info.AC[mt.a_index - 1]))
-
-        # find the minimal representation for each variant
-        mt = mt.annotate_rows(minrep=hl.min_rep(mt.locus, mt.alleles))
-
-        # rotate the table key(s)
-        mt = mt.key_rows_by(
-            locus=mt.minrep.locus,
-            alleles=mt.minrep.alleles,
-        )
+        # run splitting and normalisation
+        mt = split_and_normalise(mt)
 
         loguru.logger.info(f'Writing fresh data into {dense_mt_out}')
         mt.write(dense_mt_out, overwrite=True)

--- a/src/cpg_seqr_loader/stages.py
+++ b/src/cpg_seqr_loader/stages.py
@@ -108,14 +108,20 @@ class CreateDenseMtFromVdsWithHail(stage.MultiCohortStage):
     def queue_jobs(self, multicohort: targets.MultiCohort, inputs: stage.StageInput) -> stage.StageOutput:
         outputs = self.expected_outputs(multicohort)
 
-        checkpoint_path = self.tmp_prefix / f'{multicohort.get_alignment_inputs_hash()}_densified_checkpoint.mt'
+        # there was a correction to underlying cpg-flow behaviour, fixing MC.hash, but to reduce costs and resume from
+        # prior work during a troubleshooting phase, we want to manually set a specific path to resume from.
+        # ideally we phase this back out, as it could be a bit of a footgun
+        checkpoint_path = config.config_retrieve(
+            ['combiner', 'densify_checkpoint'],
+            str(self.tmp_prefix / f'{multicohort.get_alignment_inputs_hash()}_densified_checkpoint.mt'),
+        )
 
         job = generate_densify_jobs(
             input_vds=inputs.as_str(multicohort, CombineGvcfsIntoVds, 'vds'),
             output_mt=outputs['mt'],
             output_sites_only=outputs['hps_vcf_dir'],
             output_separate_header=outputs['separate_header_vcf_dir'],
-            checkpoint=str(checkpoint_path),
+            checkpoint=checkpoint_path,
             job_attrs=self.get_job_attrs(multicohort),
         )
         return self.make_outputs(target=multicohort, data=outputs, jobs=job)


### PR DESCRIPTION
# Purpose

  - Checkpoint resume doesn't appear to be working

during a recent combiner run and re-run, the densified MT was checkpointed with 1000 partitions as expected. Restarting the workflow should have re-used that checkpointed MT, but instead a batch ([here](https://batch.hail.populationgenomics.org.au/batches/1129059)) started with ~100k jobs scheduled. This job count matches the original VDS, not the checkpoint, so I wanted to make the code and logging much more explicit about when a checkpoint it being reused. 

## Proposed Changes

  - Allows for a checkpoint path to be taken from config. This is a side effect of a CPG-Flow fix [here](https://github.com/populationgenomics/cpg-flow/pull/168), which would now use a different checkpoint path, so we'd lose the ~$70 of prior work. This should only be relevant for this run, and we can phase out soon after
  - Explicit code paths for checking if the checkpoint MT exists and can be reused. Instead of writing/reading with `mt = mt.checkpoint(checkpoint_path, _read_if_exists=True)` (based on the number of submitted jobs I don't think this was working), there are now code loops for:

    1. does the final MT exist? if yes use it, if no:
    2. does the checkpoint exist? if yes use it, if no:
    3. run densification from VDS

  - the separate steps (VDS -> dense MT, dense MT -> annotated MT, annotated MT -> split and normalised MT) are all broken out into separate methods. This makes the diff a little alarming, sorry about that

## BONUS

I've tinkered with the github CI docker builder workflow. It now runs only on pull_requests, will only create a new image if the PR isn't in draft, and will run with fixed concurrency, i.e. if you push twice in quick succession, the trailing docker builder job will be terminated. Inspired by https://stackoverflow.com/questions/66335225/how-to-cancel-previous-runs-in-the-pr-when-you-push-new-commitsupdate-the-curre/72408109#72408109

## Checklist

- [x] Version Bump!
- [ ] Related GitHub Issue created
- [ ] Tests covering new change
- [x] Linting checks pass
