### PR TITLE
Update explicit usage of intervals

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM australia-southeast1-docker.pkg.dev/cpg-common/images/cpg_hail_gcloud:0.2.138.cpg1-1
 
 ENV PYTHONDONTWRITEBYTECODE=1
-ENV VERSION=0.1.24
+ENV VERSION=0.2.0
 
 WORKDIR /cpg_seqr_loader
 

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ CPG-Flow workflows are operated entirely by defining input Cohorts (see [here](h
 ```bash
 analysis-runner \
     --skip-repo-checkout \
-    --image australia-southeast1-docker.pkg.dev/cpg-common/images/cpg-flow-seqr-loader:0.1.24-1 \
+    --image australia-southeast1-docker.pkg.dev/cpg-common/images/cpg-flow-seqr-loader:0.2.0-1 \
     --config src/cpg_seqr_loader/config_template.toml \
     --config cohorts.toml \  # containing the inputs_cohorts and sequencing_type
     --dataset seqr \
@@ -70,7 +70,7 @@ analysis-runner \
 ```bash
 analysis-runner \
     --skip-repo-checkout \
-    --image australia-southeast1-docker.pkg.dev/cpg-common/images/cpg-flow-seqr-loader:0.1.24-1 \
+    --image australia-southeast1-docker.pkg.dev/cpg-common/images/cpg-flow-seqr-loader:0.2.0-1 \
     --config src/cpg_seqr_loader/config_template.toml \
     --config cohorts.toml \  # containing the inputs_cohorts and sequencing_type
     --dataset seqr \

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ description='Seqr-Loader (gVCF-combiner) implemented in CPG-Flow'
 readme = "README.md"
 # currently cpg-flow is pinned to this version
 requires-python = ">=3.10,<3.12"
-version="0.1.24"
+version="0.2.0"
 license={"file" = "LICENSE"}
 classifiers=[
     'Environment :: Console',
@@ -120,7 +120,7 @@ hail = ["hail"]
 "src/cpg_seqr_loader/scripts/annotate_cohort.py" = ["E501"]
 
 [tool.bumpversion]
-current_version = "0.1.24"
+current_version = "0.2.0"
 parse = "(?P<major>\\d+)\\.(?P<minor>\\d+)\\.(?P<patch>\\d+)"
 serialize = ["{major}.{minor}.{patch}"]
 commit = true

--- a/src/cpg_seqr_loader/config_template.toml
+++ b/src/cpg_seqr_loader/config_template.toml
@@ -44,7 +44,6 @@ target_records = 30000000
 sg_remove_threshold = 20
 sg_remove_confirm = false
 
-# should these specific documents be committed privately?
 [combiner.densify_intervals]
 exome = 'gs://cpg-seqr-main/exome_based_intervals/100_var_balanced_intervals.bed'
 genome = 'gs://cpg-seqr-main/genome_based_intervals/1000_var_balanced_intervals.bed'

--- a/src/cpg_seqr_loader/config_template.toml
+++ b/src/cpg_seqr_loader/config_template.toml
@@ -44,14 +44,14 @@ target_records = 30000000
 sg_remove_threshold = 20
 sg_remove_confirm = false
 
-# these specific documents should be committed privately
+# should these specific documents be committed privately?
 [combiner.densify_intervals]
-exome = ''
-genome = ''
+exome = 'gs://cpg-seqr-main/exome_based_intervals/100_var_balanced_intervals.bed'
+genome = 'gs://cpg-seqr-main/genome_based_intervals/1000_var_balanced_intervals.bed'
 
 [combiner.vds_intervals]
-exome = ''
-genome = ''
+exome = 'gs://cpg-seqr-main/exome_based_intervals/5000_var_balanced_intervals.bed'
+genome = 'gs://cpg-seqr-main/genome_based_intervals/2000_var_balanced_intervals.bed'
 
 [annotate_dataset]
 # highem, standard, or a string, e.g. "4Gi"

--- a/src/cpg_seqr_loader/config_template.toml
+++ b/src/cpg_seqr_loader/config_template.toml
@@ -49,8 +49,8 @@ exome = 'gs://cpg-seqr-main/exome_based_intervals/100_var_balanced_intervals.bed
 genome = 'gs://cpg-seqr-main/genome_based_intervals/1000_var_balanced_intervals.bed'
 
 [combiner.vds_intervals]
-exome = 'gs://cpg-seqr-main/exome_based_intervals/5000_var_balanced_intervals.bed'
-genome = 'gs://cpg-seqr-main/genome_based_intervals/2000_var_balanced_intervals.bed'
+exome = 'gs://cpg-seqr-main/exome_based_intervals/2000_var_balanced_intervals.bed'
+genome = 'gs://cpg-seqr-main/genome_based_intervals/5000_var_balanced_intervals.bed'
 
 [annotate_dataset]
 # highem, standard, or a string, e.g. "4Gi"

--- a/src/cpg_seqr_loader/config_template.toml
+++ b/src/cpg_seqr_loader/config_template.toml
@@ -35,19 +35,23 @@ branch_factor = 50
 # the number of intermediate merges to run in parallel with each step
 gvcf_batch_size = 5
 
-# when merging multiple VDS, we find the largest VDS, repartition to target_records variants per partition
-# then repartition all VDSs to match those intervals prior to merging
-target_records = 30000
+# Hail's default interval strategy + target number of 'records' (variants) per interval is very low, leading to a high
+# level of fragmentation. Instead of accepting those irritating constraints we provide our own intervals, and overwrite
+# default arguments like target_records which would override those and deliver high partition counts
+target_records = 30000000
 
 # if the process will remove a large number of SGs from the combiner, require this config setting to confirm intent
 sg_remove_threshold = 20
 sg_remove_confirm = false
 
-# Number of paritions to use when densifying VDS to MT
-densify_partitions = 1000
-# option to use naive coalesce for densification, which may be less efficient but can bypass
-# some bugs related to Hail calculating partitions based on the VDS
-densify_partitions_naive_coalesce = false
+# these specific documents should be committed privately
+[combiner.densify_intervals]
+exome = ''
+genome = ''
+
+[combiner.vds_intervals]
+exome = ''
+genome = ''
 
 [annotate_dataset]
 # highem, standard, or a string, e.g. "4Gi"

--- a/src/cpg_seqr_loader/jobs/AnnotateCohort.py
+++ b/src/cpg_seqr_loader/jobs/AnnotateCohort.py
@@ -20,6 +20,7 @@ def create_annotate_cohort_job(
     )
     job.image(config.config_retrieve(['workflow', 'driver_image']))
     job.cpu(2).memory('highmem').storage('10Gi')
+    job.spot(False)
     job.command(
         f"""
         python -m cpg_seqr_loader.scripts.annotate_cohort \\

--- a/src/cpg_seqr_loader/jobs/AnnotateDataset.py
+++ b/src/cpg_seqr_loader/jobs/AnnotateDataset.py
@@ -21,6 +21,7 @@ def create_annotate_dataset_job(
     job.cpu(2).memory('highmem').storage('10Gi')
 
     job.image(config.config_retrieve(['workflow', 'driver_image']))
+    job.spot(False)
     job.command(
         f"""
         python -m cpg_seqr_loader.scripts.annotate_dataset \\

--- a/src/cpg_seqr_loader/jobs/CombineGvcfsIntoVds.py
+++ b/src/cpg_seqr_loader/jobs/CombineGvcfsIntoVds.py
@@ -105,7 +105,7 @@ def create_combiner_jobs(
 
     # set this job to be non-spot (i.e. non-preemptible)
     # previous issues with preemptible VMs led to multiple simultaneous QOB groups processing the same data
-    job.spot(config.config_retrieve(['workflow', 'preemptible_vms']))
+    job.spot(False)
 
     input_vds_arg = f'--input_vds {vds_path!s}' if vds_path else ''
 

--- a/src/cpg_seqr_loader/jobs/CreateDenseMtFromVdsWithHail.py
+++ b/src/cpg_seqr_loader/jobs/CreateDenseMtFromVdsWithHail.py
@@ -17,7 +17,7 @@ def generate_densify_jobs(
     job = hail_batch.get_batch().new_bash_job('Densify VDS and export MT', attributes=job_attrs | {'tool': 'hail'})
     job.image(config.config_retrieve(['workflow', 'driver_image']))
 
-    job.spot(is_spot=False)
+    job.spot(False)
 
     job.command(
         f"""

--- a/src/cpg_seqr_loader/jobs/SubsetMtToDatasetWithHail.py
+++ b/src/cpg_seqr_loader/jobs/SubsetMtToDatasetWithHail.py
@@ -11,7 +11,7 @@ if TYPE_CHECKING:
 
 def create_subset_mt_job(
     dataset: targets.Dataset,
-    input_mt: str,
+    input_mt: Path,
     id_file: Path,
     output_mt: Path,
     job_attrs: dict[str, str],
@@ -32,6 +32,7 @@ def create_subset_mt_job(
     )
     job.image(config.config_retrieve(['workflow', 'driver_image']))
     job.cpu(2).memory('highmem').storage('10Gi')
+    job.spot(False)
     job.command(
         f"""
         python -m cpg_seqr_loader.scripts.subset_mt_to_dataset \\

--- a/src/cpg_seqr_loader/scripts/create_preset_intervals.py
+++ b/src/cpg_seqr_loader/scripts/create_preset_intervals.py
@@ -216,7 +216,7 @@ def main(input_path: str, count: list[int], meres: str, output: str):
         intervals[-1] = (last_chr, last_start, hl.get_reference('GRCh38').lengths[last_chr])
 
         # and shove on a single max region for mitochondria, removing a previous mito interval if it was in the list
-        intervals.append(('chrM', 1, 16569))
+        intervals.append(('chrM', 1, hl.get_reference('GRCh38').lengths['chrM']))
 
         with (output_root / f'{interval_count}_var_balanced_intervals.bed').open('w') as f:
             for contig, start, end in intervals:

--- a/src/cpg_seqr_loader/scripts/create_preset_intervals.py
+++ b/src/cpg_seqr_loader/scripts/create_preset_intervals.py
@@ -203,7 +203,10 @@ def main(input_path: str, count: list[int], meres: str, output: str):
         # for now, removing the contig-spanning and telo/cetromere bridging interval reshaping logic
         # better_intervals = polish_intervals(intervals, centromeres, telomeres)  # noqa: ERA001
 
-        # and shove on a single region for mitochondria
+        # and shove on a single region for mitochondria, removing a previous mito interval if it was in the list
+        if intervals[-1][0] == 'chrM':
+            _chr_m_pop = intervals.pop(-1)
+
         intervals.append(('chrM', 1, 16569))
 
         with (output_root / f'{interval_count}_var_balanced_intervals.bed').open('w') as f:

--- a/src/cpg_seqr_loader/scripts/create_preset_intervals.py
+++ b/src/cpg_seqr_loader/scripts/create_preset_intervals.py
@@ -200,13 +200,22 @@ def main(input_path: str, count: list[int], meres: str, output: str):
     for interval_count in count:
         intervals = get_naive_intervals(ht, interval_count)
 
-        # for now, removing the contig-spanning and telo/cetromere bridging interval reshaping logic
-        # better_intervals = polish_intervals(intervals, centromeres, telomeres)  # noqa: ERA001
+        # do a little bit of interval grooming - hail will only divide the variants it sees, so there is a possibility
+        # of as-yet-unseen variants occuring before the observed chr1 variants, or after the final observed variant
 
-        # and shove on a single region for mitochondria, removing a previous mito interval if it was in the list
+        # set the first base of the first interval on chr1 to 1, to maximise included regions
+        first_chr, first_start, first_end = intervals[0]
+        intervals[0] = (first_chr, 1, first_end)
+
+        # remove a final interval on chrM if present
         if intervals[-1][0] == 'chrM':
             _chr_m_pop = intervals.pop(-1)
 
+        # maximise the final non-chrM interval to the end of the contig
+        last_chr, last_start, last_end = intervals[-1]
+        intervals[-1] = (last_chr, last_start, hl.get_reference('GRCh38').lengths[last_chr])
+
+        # and shove on a single max region for mitochondria, removing a previous mito interval if it was in the list
         intervals.append(('chrM', 1, 16569))
 
         with (output_root / f'{interval_count}_var_balanced_intervals.bed').open('w') as f:

--- a/src/cpg_seqr_loader/scripts/densify_VDS_to_MT.py
+++ b/src/cpg_seqr_loader/scripts/densify_VDS_to_MT.py
@@ -38,6 +38,7 @@ def densify(vds_path: str, checkpoint_path: str) -> hl.MatrixTable:
 
     sequencing_type = config.config_retrieve(['workflow', 'sequencing_type'])
     intervals_path = config.config_retrieve(['combiner', 'vds_intervals', sequencing_type])
+
     if not intervals_path:
         raise ValueError(f'Provided path for MT intervals: {intervals_path} - please provide a real path.')
 

--- a/src/cpg_seqr_loader/scripts/densify_VDS_to_MT.py
+++ b/src/cpg_seqr_loader/scripts/densify_VDS_to_MT.py
@@ -42,7 +42,7 @@ def densify(vds_path: str, checkpoint_path: str) -> hl.MatrixTable:
     if not intervals_path:
         raise ValueError(f'Provided path for MT intervals: {intervals_path} - please provide a real path.')
 
-    intervals = hl.import_bed(intervals_path, reference_genome='GRCh38').interval.collect()
+    intervals = hl.import_bed(intervals_path, reference_genome=hail_batch.genome_build()).interval.collect()
 
     # read the VDS with pre-defined intervals
     vds = hl.vds.read_vds(vds_path, intervals=intervals)

--- a/src/cpg_seqr_loader/scripts/densify_VDS_to_MT.py
+++ b/src/cpg_seqr_loader/scripts/densify_VDS_to_MT.py
@@ -37,7 +37,7 @@ def densify(vds_path: str, checkpoint_path: str) -> hl.MatrixTable:
     """
 
     sequencing_type = config.config_retrieve(['workflow', 'sequencing_type'])
-    intervals_path = config.config_retrieve(['combiner', 'vds_intervals', sequencing_type])
+    intervals_path = config.config_retrieve(['combiner', 'densify_intervals', sequencing_type])
 
     if not intervals_path:
         raise ValueError(f'Provided path for MT intervals: {intervals_path} - please provide a real path.')

--- a/src/cpg_seqr_loader/scripts/densify_VDS_to_MT.py
+++ b/src/cpg_seqr_loader/scripts/densify_VDS_to_MT.py
@@ -24,30 +24,28 @@ from cpg_seqr_loader.hail_scripts.sparse_mt import default_compute_info
 from cpg_seqr_loader.hail_scripts.vcf import adjust_vcf_incompatible_types
 
 
-def densify(vds_path: str, partitions: int, checkpoint_path: str) -> hl.MatrixTable:
+def densify(vds_path: str, checkpoint_path: str) -> hl.MatrixTable:
     """
     Segregating the densification logic out here - this method reads in a VDS, densifies, repartitions, and checkpoints
 
     Args:
         vds_path: where to find the VDS input (in GCS)
-        partitions: how many partitions to use
         checkpoint_path: where to write the resulting MT (in GCS)
 
     Returns:
         the resulting MatrixTable
     """
 
-    # providing n_partitions here gets Hail to calculate the intervals per partition on the VDS var and ref data
-    # however there are bugs that can cause this to error out, so we have an option to bypass this
-    # with a naive coalesce instead, which will just combine partitions after the fact
-    if config.config_retrieve(['combiner', 'densify_partitions_naive_coalesce'], False):
-        loguru.logger.info('Using naive coalesce for densification')
-        vds = hl.vds.read_vds(vds_path)
-        mt = hl.vds.to_dense_mt(vds)
-        mt = mt.naive_coalesce(partitions)
-    else:
-        vds = hl.vds.read_vds(vds_path, n_partitions=partitions)
-        mt = hl.vds.to_dense_mt(vds)
+    sequencing_type = config.config_retrieve(['workflow', 'sequencing_type'])
+    intervals_path = config.config_retrieve(['combiner', 'vds_intervals', sequencing_type])
+    if not intervals_path:
+        raise ValueError(f'Provided path for MT intervals: {intervals_path} - please provide a real path.')
+
+    intervals = hl.import_bed(intervals_path, reference_genome='GRCh38').interval.collect()
+
+    # read the VDS with pre-defined intervals
+    vds = hl.vds.read_vds(vds_path, intervals=intervals)
+    mt = hl.vds.to_dense_mt(vds)
 
     # taken from _filter_rows_and_add_tags in large_cohort/site_only_vcf.py
     # remove any monoallelic or non-ref-in-any-sample sites
@@ -167,12 +165,8 @@ def main(
         driver_cores=config.config_retrieve(['combiner', 'driver_cores'], 2),
     )
 
-    partitions = config.config_retrieve(['combiner', 'densify_partitions'], 1000)
-
     # check here to see if we can reuse the dense MT
     if not utils.can_reuse(dense_mt_out):
-        loguru.logger.info(f'Densifying data, using {partitions} partitions')
-
         # and check here to see if we can re-use the checkpoint
         if utils.can_reuse(checkpoint_path):
             loguru.logger.info(f'Resuming from a densified checkpoint: {checkpoint_path}')
@@ -180,7 +174,7 @@ def main(
 
         else:
             loguru.logger.info(f'Running a VDS -> with densification, checkpointing to {checkpoint_path}')
-            mt = densify(vds_in, partitions, checkpoint_path)
+            mt = densify(vds_in, checkpoint_path)
 
         # run the INFO field generation/annotation process
         mt = generate_mt_info(mt)

--- a/src/cpg_seqr_loader/scripts/run_combiner.py
+++ b/src/cpg_seqr_loader/scripts/run_combiner.py
@@ -136,7 +136,7 @@ def main(
     if not vds_intervals_path:
         raise ValueError(f'Provided path for VDS intervals: {vds_intervals_path} - please provide a real path.')
 
-    vds_intervals = hl.import_bed(vds_intervals_path, reference_genome='GRCh38').interval.collect()
+    vds_intervals = hl.import_bed(vds_intervals_path, reference_genome=hail_batch.genome_build()).interval.collect()
 
     # 2 - do we need to run the combiner?
     hl.vds.new_combiner(
@@ -144,7 +144,7 @@ def main(
         save_path=combiner_plan,
         gvcf_paths=gvcf_paths,
         vds_paths=[vds_path] if vds_path else None,
-        reference_genome='GRCh38',
+        reference_genome=hail_batch.genome_build(),
         temp_path=tmp_prefix,
         force=force_new_combiner,
         intervals=vds_intervals,

--- a/src/cpg_seqr_loader/scripts/run_combiner.py
+++ b/src/cpg_seqr_loader/scripts/run_combiner.py
@@ -127,8 +127,10 @@ def main(
 
     # for Combining phase, aim for a high number of partitions, ~5k
     vds_intervals_path = config.config_retrieve(['combiner', 'vds_intervals', sequencing_type])
+
     if not vds_intervals_path:
         raise ValueError(f'Provided path for VDS intervals: {vds_intervals_path} - please provide a real path.')
+
     vds_intervals = hl.import_bed(vds_intervals_path, reference_genome='GRCh38').interval.collect()
 
     # 2 - do we need to run the combiner?

--- a/src/cpg_seqr_loader/scripts/run_combiner.py
+++ b/src/cpg_seqr_loader/scripts/run_combiner.py
@@ -48,9 +48,8 @@ def main(
         worker_cores=config.config_retrieve(['combiner', 'worker_cores']),
     )
 
-    # generate these in the job, instead of passing through
+    # this may be overwritten
     force_new_combiner = config.config_retrieve(['combiner', 'force_new_combiner'])
-    sequencing_type = config.config_retrieve(['workflow', 'sequencing_type'])
 
     # Load from save, if supplied (log correctly depending on force_new_combiner)
     if combiner_plan and force_new_combiner:
@@ -123,23 +122,31 @@ def main(
             vds.write(temp_path)
             vds_path = temp_path
 
+    # final round of combiner arguments from config
+    sequencing_type = config.config_retrieve(['workflow', 'sequencing_type'])
+
+    # for Combining phase, aim for a high number of partitions, ~5k
+    vds_intervals_path = config.config_retrieve(['combiner', 'vds_intervals', sequencing_type])
+    if not vds_intervals_path:
+        raise ValueError(f'Provided path for VDS intervals: {vds_intervals_path} - please provide a real path.')
+    vds_intervals = hl.import_bed(vds_intervals_path, reference_genome='GRCh38').interval.collect()
+
     # 2 - do we need to run the combiner?
-    combiner = hl.vds.new_combiner(
+    hl.vds.new_combiner(
         output_path=output_vds_path,
         save_path=combiner_plan,
         gvcf_paths=gvcf_paths,
         vds_paths=[vds_path] if vds_path else None,
-        reference_genome=hail_batch.genome_build(),
+        reference_genome='GRCh38',
         temp_path=tmp_prefix,
-        use_exome_default_intervals=sequencing_type == 'exome',
-        use_genome_default_intervals=sequencing_type == 'genome',
         force=force_new_combiner,
+        intervals=vds_intervals,
         branch_factor=config.config_retrieve(['combiner', 'branch_factor']),
-        target_records=config.config_retrieve(['combiner', 'target_records']),
+        target_records=config.config_retrieve(
+            ['combiner', 'target_records']
+        ),  # keep this high to prevent hail overriding preset partitions
         gvcf_batch_size=config.config_retrieve(['combiner', 'gvcf_batch_size']),
-    )
-
-    combiner.run()
+    ).run()
 
 
 if __name__ == '__main__':

--- a/src/cpg_seqr_loader/scripts/run_combiner.py
+++ b/src/cpg_seqr_loader/scripts/run_combiner.py
@@ -9,7 +9,7 @@ import logging
 
 import loguru
 from cpg_flow import utils
-from cpg_utils import config, hail_batch
+from cpg_utils import config, hail_batch, to_path
 
 import hail as hl
 
@@ -48,17 +48,21 @@ def main(
         worker_cores=config.config_retrieve(['combiner', 'worker_cores']),
     )
 
-    # this may be overwritten
+    # allow force-new from config. This would force a fresh combining of the input gVCFs and prior VDSs as appropriate
+    # it would not restart a completely fresh VDS from component gVCFs
+    # this is relevant for instances where a previous combiner attempt started, but failed due to resourcing issues, and
+    # we want to start fresh with new intervals/partition strategy
     force_new_combiner = config.config_retrieve(['combiner', 'force_new_combiner'])
 
     # Load from save, if supplied (log correctly depending on force_new_combiner)
     if combiner_plan and force_new_combiner:
         loguru.logger.info(f'Combiner plan {combiner_plan} will be ignored/written new')
 
-    elif combiner_plan:
-        loguru.logger.info(f'Resuming combiner plan from {combiner_plan}')
+    # combiner plan as an argument comes from the Stage, so it always has a real value, but the file may not exist.
+    elif combiner_plan and to_path(combiner_plan).exists():
+        loguru.logger.info(f'Resuming combiner plan from {combiner_plan}.')
 
-    # do we have new content to add?
+    # do we have new gVCFs to add?
     if gvcfs_to_combine_file is not None:
         # if gvcfs_to_combine is a file, read it and split into a list
         with open(gvcfs_to_combine_file) as f:
@@ -66,7 +70,7 @@ def main(
     else:
         gvcf_paths = None
 
-    # do we have any SGs to remove?
+    # do we have any SGs to remove? i.e. scenarios where we have to remove SGs due to retraction
     if sgs_to_remove_file is not None:
         # if gvcfs_to_combine is a file, read it and split into a list
         with open(sgs_to_remove_file) as f:
@@ -84,6 +88,7 @@ def main(
     else:
         sgs_to_remove = None
 
+    # if neither of these are true, we don't need to be here - the Stage should not be running.
     if not (sgs_to_remove or gvcf_paths):
         raise ValueError('No samples to remove or gVCFs to add - please provide at least one of these')
 


### PR DESCRIPTION
# Purpose

  - Overrides hail default and variant-distribution-unaware partitioning strategies with variant-distribution derived choices
  - Ideal outcome - combining operations are a rational balance of high parallelisation + high work-per-shard, and all downstream operations are run on variant-equal data partitions.

# Rationale

  - When we generate VDSs, Hail is using ill-informed default partitions as a starting point (obtained based on equal base-span per interval, not equal variant density), then further fragmenting those partitions by splitting at a very low target_records (per interval) parameter (default 24k, we were overriding to only 30k). For genomes this is generating ~120k partitions, which creates a high degree of QOB overhead, and very short-running individual jobs.
    - For context splitting our current genome callset's ~150m variants by 30000 should only result in 5000 intervals, so the two strategies interact badly
  - When we densify this data into fewer partitions (to support parallelised operations downstream, where 120k parallel jobs would create a massive cost overhead), coalescing the data into fewer intervals is based on the initial partitions, so we continue to see imbalanced datasets, causing hardware and runtime issues.
  - There are other fun issues in the VDS -> MT transition, where hail's internal repartitioning of a VDS dataset might be a fair distribution of either the reference or variant data, but will not be a fair splitting of both. Curated intervals should solve this.

## Proposed Changes

  - builds on #42, which added a process to generate variant-balanced partitions based on a real variant distribution. The distribution of choice is our latest Exome and Genome joint-callsets to be maximally representative, but gnomAD data is available for an idealised distribution
  - also borrows from a similar approach in the PopGen work [here](https://github.com/populationgenomics/ourdna_genomic_atlas/blob/main/src/ourdna_genomic_atlas/jobs/combiner_job.py#L202)
  - Adds a relatively high number of partitions as inputs to the combiner process, to manually shape the number of partitions being used in combining work. 
  - Adds a lower number of partitions, derived from the same original variant distribution, to densify into.
  - Overrides the target_records value to be an unreachably high value, so that Hail won't intervene and further split the input partitions.

## Related

Interval generation jobs (the config currently addresses file paths which don't exist)
  - https://batch.hail.populationgenomics.org.au/batches/1129383
  - https://batch.hail.populationgenomics.org.au/batches/1129384

## Additional content

  - the create_preset_intervals script splits a **known dataset** into a requested number of partitions
  - because this is our non-mito pipeline, it was expected that the dataset wouldn't contain mitochondrial results, so the script wouldn't generate a chrM interval by default - the script manually adds one
  - when run on gnomAD data this worked as expected (no chrM)
  - when run on our real MTs, we had chrM variants, so there was a chrM interval
  - the start of chr1 and the end of chrM were with respect to the first and final variants seen in the dataset, not the full span of those contigs.

### Changes!

Once we gather all intervals from the dataset, we:
1. set the first interval's start position to 1
2. remove the final interval if it was chrM
3. set the final interval's end to len(contig)
4. add a maximal chrM contig

## Checklist

- [x] Version Bump!
- [ ] Related GitHub Issue created
- [ ] Tests covering new change
- [x] Linting checks pass
