### PR TITLE
Manually read intervals

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM australia-southeast1-docker.pkg.dev/cpg-common/images/cpg_hail_gcloud:0.2.138.cpg1-1
 
 ENV PYTHONDONTWRITEBYTECODE=1
-ENV VERSION=0.2.0
+ENV VERSION=0.2.1
 
 WORKDIR /cpg_seqr_loader
 

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ CPG-Flow workflows are operated entirely by defining input Cohorts (see [here](h
 ```bash
 analysis-runner \
     --skip-repo-checkout \
-    --image australia-southeast1-docker.pkg.dev/cpg-common/images/cpg-flow-seqr-loader:0.2.0-1 \
+    --image australia-southeast1-docker.pkg.dev/cpg-common/images/cpg-flow-seqr-loader:0.2.1-1 \
     --config src/cpg_seqr_loader/config_template.toml \
     --config cohorts.toml \  # containing the inputs_cohorts and sequencing_type
     --dataset seqr \
@@ -70,7 +70,7 @@ analysis-runner \
 ```bash
 analysis-runner \
     --skip-repo-checkout \
-    --image australia-southeast1-docker.pkg.dev/cpg-common/images/cpg-flow-seqr-loader:0.2.0-1 \
+    --image australia-southeast1-docker.pkg.dev/cpg-common/images/cpg-flow-seqr-loader:0.2.1-1 \
     --config src/cpg_seqr_loader/config_template.toml \
     --config cohorts.toml \  # containing the inputs_cohorts and sequencing_type
     --dataset seqr \

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ description='Seqr-Loader (gVCF-combiner) implemented in CPG-Flow'
 readme = "README.md"
 # currently cpg-flow is pinned to this version
 requires-python = ">=3.10,<3.12"
-version="0.2.0"
+version="0.2.1"
 license={"file" = "LICENSE"}
 classifiers=[
     'Environment :: Console',
@@ -120,7 +120,7 @@ hail = ["hail"]
 "src/cpg_seqr_loader/scripts/annotate_cohort.py" = ["E501"]
 
 [tool.bumpversion]
-current_version = "0.2.0"
+current_version = "0.2.1"
 parse = "(?P<major>\\d+)\\.(?P<minor>\\d+)\\.(?P<patch>\\d+)"
 serialize = ["{major}.{minor}.{patch}"]
 commit = true

--- a/src/cpg_seqr_loader/scripts/densify_VDS_to_MT.py
+++ b/src/cpg_seqr_loader/scripts/densify_VDS_to_MT.py
@@ -16,12 +16,13 @@ import argparse
 
 import loguru
 from cpg_flow import utils
-from cpg_utils import config, hail_batch, to_path
+from cpg_utils import config, hail_batch
 
 import hail as hl
 
 from cpg_seqr_loader.hail_scripts.sparse_mt import default_compute_info
 from cpg_seqr_loader.hail_scripts.vcf import adjust_vcf_incompatible_types
+from cpg_seqr_loader.utils import read_bed_file_as_intervals
 
 
 def densify(vds_path: str, checkpoint_path: str) -> hl.MatrixTable:
@@ -43,18 +44,7 @@ def densify(vds_path: str, checkpoint_path: str) -> hl.MatrixTable:
         raise ValueError(f'Provided path for MT intervals: {intervals_path} - please provide a real path.')
 
     # read intervals BED file manually
-    intervals: list[hl.Interval] = []
-    with to_path(intervals_path).open() as bed_handle:
-        for line in bed_handle:
-            stripped = line.strip()
-            if not stripped:
-                continue
-
-            chrom, start, end = stripped.split()[:3]
-
-            start_locus = hl.Locus(chrom, int(start) + 1, reference_genome='GRCh38')
-            end_locus = hl.Locus(chrom, int(end), reference_genome='GRCh38')
-            intervals.append(hl.Interval(start_locus, end_locus, includes_start=True, includes_end=True))
+    intervals: list[hl.Interval] = read_bed_file_as_intervals(intervals_path)
 
     # read the VDS with pre-defined intervals
     vds = hl.vds.read_vds(vds_path, intervals=intervals)

--- a/src/cpg_seqr_loader/scripts/densify_VDS_to_MT.py
+++ b/src/cpg_seqr_loader/scripts/densify_VDS_to_MT.py
@@ -16,7 +16,7 @@ import argparse
 
 import loguru
 from cpg_flow import utils
-from cpg_utils import config, hail_batch
+from cpg_utils import config, hail_batch, to_path
 
 import hail as hl
 
@@ -42,7 +42,19 @@ def densify(vds_path: str, checkpoint_path: str) -> hl.MatrixTable:
     if not intervals_path:
         raise ValueError(f'Provided path for MT intervals: {intervals_path} - please provide a real path.')
 
-    intervals = hl.import_bed(intervals_path, reference_genome=hail_batch.genome_build()).interval.collect()
+    # read intervals BED file manually
+    intervals: list[hl.Interval] = []
+    with to_path(intervals_path).open() as bed_handle:
+        for line in bed_handle:
+            stripped = line.strip()
+            if not stripped:
+                continue
+
+            chrom, start, end = stripped.split()[:3]
+
+            start_locus = hl.Locus(chrom, int(start) + 1, reference_genome='GRCh38')
+            end_locus = hl.Locus(chrom, int(end), reference_genome='GRCh38')
+            intervals.append(hl.Interval(start_locus, end_locus, includes_start=True, includes_end=True))
 
     # read the VDS with pre-defined intervals
     vds = hl.vds.read_vds(vds_path, intervals=intervals)

--- a/src/cpg_seqr_loader/scripts/run_combiner.py
+++ b/src/cpg_seqr_loader/scripts/run_combiner.py
@@ -13,6 +13,8 @@ from cpg_utils import config, hail_batch, to_path
 
 import hail as hl
 
+from cpg_seqr_loader.utils import read_bed_file_as_intervals
+
 
 def main(
     output_vds_path: str,
@@ -137,18 +139,7 @@ def main(
         raise ValueError(f'Provided path for VDS intervals: {vds_intervals_path} - please provide a real path.')
 
     # read intervals BED file manually
-    vds_intervals: list[hl.Interval] = []
-    with to_path(vds_intervals_path).open() as bed_handle:
-        for line in bed_handle:
-            stripped = line.strip()
-            if not stripped:
-                continue
-
-            chrom, start, end = stripped.split()[:3]
-
-            start_locus = hl.Locus(chrom, int(start) + 1, reference_genome='GRCh38')
-            end_locus = hl.Locus(chrom, int(end), reference_genome='GRCh38')
-            vds_intervals.append(hl.Interval(start_locus, end_locus, includes_start=True, includes_end=True))
+    vds_intervals: list[hl.Interval] = read_bed_file_as_intervals(vds_intervals_path)
 
     # 2 - do we need to run the combiner?
     hl.vds.new_combiner(

--- a/src/cpg_seqr_loader/scripts/run_combiner.py
+++ b/src/cpg_seqr_loader/scripts/run_combiner.py
@@ -136,7 +136,19 @@ def main(
     if not vds_intervals_path:
         raise ValueError(f'Provided path for VDS intervals: {vds_intervals_path} - please provide a real path.')
 
-    vds_intervals = hl.import_bed(vds_intervals_path, reference_genome=hail_batch.genome_build()).interval.collect()
+    # read intervals BED file manually
+    vds_intervals: list[hl.Interval] = []
+    with to_path(vds_intervals_path).open() as bed_handle:
+        for line in bed_handle:
+            stripped = line.strip()
+            if not stripped:
+                continue
+
+            chrom, start, end = stripped.split()[:3]
+
+            start_locus = hl.Locus(chrom, int(start) + 1, reference_genome='GRCh38')
+            end_locus = hl.Locus(chrom, int(end), reference_genome='GRCh38')
+            vds_intervals.append(hl.Interval(start_locus, end_locus, includes_start=True, includes_end=True))
 
     # 2 - do we need to run the combiner?
     hl.vds.new_combiner(

--- a/src/cpg_seqr_loader/utils.py
+++ b/src/cpg_seqr_loader/utils.py
@@ -9,7 +9,7 @@ from typing import TYPE_CHECKING
 
 import loguru
 from cpg_flow import targets
-from cpg_utils import Path, config, hail_batch
+from cpg_utils import Path, config, hail_batch, to_path
 from metamist.graphql import gql, query
 
 import hail as hl
@@ -119,6 +119,24 @@ SPECIFIC_VDS_QUERY = gql(
     }
 """,
 )
+
+
+def read_bed_file_as_intervals(bed_path: str) -> list[hl.Interval]:
+    """Manually interpret an input BED file as a series of Intervals."""
+    # read intervals BED file manually
+    intervals: list[hl.Interval] = []
+    with to_path(bed_path).open() as bed_handle:
+        for line in bed_handle:
+            stripped = line.strip()
+            if not stripped:
+                continue
+
+            chrom, start, end = stripped.split()[:3]
+
+            start_locus = hl.Locus(chrom, int(start) + 1, reference_genome='GRCh38')
+            end_locus = hl.Locus(chrom, int(end), reference_genome='GRCh38')
+            intervals.append(hl.Interval(start_locus, end_locus, includes_start=True, includes_end=True))
+    return intervals
 
 
 @functools.cache


### PR DESCRIPTION
# Purpose

  - Well, that didn't work: https://batch.hail.populationgenomics.org.au/batches/1129494

## Proposed Changes

  - The BED file (to me) looks fine - left-inclusive, right-exclusive, shared boundaries, e.g.
  
```
chr1	1595114	2064908
chr1	2064908	2526227
```
  - parsing of these looks... reasonable? Hail is buffing the values by 1, but universally, and the `includes_start=True, includes_end=False` is consistent. I would expect this set of intervals to cover the whole genome with no gaps:
```
Interval(start=Locus(contig=chr1, position=1595115, reference_genome=GRCh38), end=Locus(contig=chr1, position=2064909, reference_genome=GRCh38), includes_start=True, includes_end=False),
Interval(start=Locus(contig=chr1, position=2064909, reference_genome=GRCh38), end=Locus(contig=chr1, position=2526228, reference_genome=GRCh38), includes_start=True, includes_end=False),
...
```
  - but Hail is breaking on variants (or reference blocks) which appear exactly on the boundary

The workflow this is based off is PopGen's, and that workflow is not using Hail's automatic parsing of the BED file. Instead it's being manually read and interpreted in this function: https://github.com/populationgenomics/ourdna_genomic_atlas/blob/main/src/ourdna_genomic_atlas/popgen_utils.py#L117

This PR suggests moving to that mode. Results of running this on the same input:
```
Interval(start=Locus(contig=chr1, position=1595115, reference_genome=GRCh38), end=Locus(contig=chr1, position=2064908, reference_genome=GRCh38), includes_start=True, includes_end=True),
Interval(start=Locus(contig=chr1, position=2064909, reference_genome=GRCh38), end=Locus(contig=chr1, position=2526227, reference_genome=GRCh38), includes_start=True, includes_end=True),
...
```

## Checklist

- [x] Version Bump!
- [ ] Related GitHub Issue created
- [ ] Tests covering new change
- [x] Linting checks pass
