### PR TITLE
Make two densification checkpoints

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
-FROM australia-southeast1-docker.pkg.dev/cpg-common/images/cpg_hail_gcloud:0.2.138.cpg1-1
+FROM australia-southeast1-docker.pkg.dev/cpg-common/images/cpg_hail_gcloud:0.2.238.cpg1-1
 
 ENV PYTHONDONTWRITEBYTECODE=1
-ENV VERSION=0.2.1
+ENV VERSION=0.2.2
 
 WORKDIR /cpg_seqr_loader
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM australia-southeast1-docker.pkg.dev/cpg-common/images/cpg_hail_gcloud:0.2.238.cpg1-1
+FROM australia-southeast1-docker.pkg.dev/cpg-common/images/cpg_hail_gcloud:0.2.138.cpg1-1
 
 ENV PYTHONDONTWRITEBYTECODE=1
 ENV VERSION=0.2.2

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ CPG-Flow workflows are operated entirely by defining input Cohorts (see [here](h
 ```bash
 analysis-runner \
     --skip-repo-checkout \
-    --image australia-southeast1-docker.pkg.dev/cpg-common/images/cpg-flow-seqr-loader:0.2.1-1 \
+    --image australia-southeast1-docker.pkg.dev/cpg-common/images/cpg-flow-seqr-loader:0.2.2-1 \
     --config src/cpg_seqr_loader/config_template.toml \
     --config cohorts.toml \  # containing the inputs_cohorts and sequencing_type
     --dataset seqr \
@@ -70,7 +70,7 @@ analysis-runner \
 ```bash
 analysis-runner \
     --skip-repo-checkout \
-    --image australia-southeast1-docker.pkg.dev/cpg-common/images/cpg-flow-seqr-loader:0.2.1-1 \
+    --image australia-southeast1-docker.pkg.dev/cpg-common/images/cpg-flow-seqr-loader:0.2.2-1 \
     --config src/cpg_seqr_loader/config_template.toml \
     --config cohorts.toml \  # containing the inputs_cohorts and sequencing_type
     --dataset seqr \

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ description='Seqr-Loader (gVCF-combiner) implemented in CPG-Flow'
 readme = "README.md"
 # currently cpg-flow is pinned to this version
 requires-python = ">=3.10,<3.12"
-version="0.2.1"
+version="0.2.2"
 license={"file" = "LICENSE"}
 classifiers=[
     'Environment :: Console',
@@ -120,7 +120,7 @@ hail = ["hail"]
 "src/cpg_seqr_loader/scripts/annotate_cohort.py" = ["E501"]
 
 [tool.bumpversion]
-current_version = "0.2.1"
+current_version = "0.2.2"
 parse = "(?P<major>\\d+)\\.(?P<minor>\\d+)\\.(?P<patch>\\d+)"
 serialize = ["{major}.{minor}.{patch}"]
 commit = true

--- a/src/cpg_seqr_loader/config_template.toml
+++ b/src/cpg_seqr_loader/config_template.toml
@@ -24,10 +24,10 @@ driver_memory = "highmem"
 # string, e.g. "4Gi"
 driver_storage = "10Gi"
 # integer
-driver_cores = 8
+driver_cores = 4
 # highem, standard, or a string, e.g. "4Gi"
 worker_memory = "highmem"
-worker_cores = 1
+worker_cores = 4
 
 # The number of gVCFs/VDSs to combine in each intermediate step
 branch_factor = 50
@@ -35,10 +35,10 @@ branch_factor = 50
 # the number of intermediate merges to run in parallel with each step
 gvcf_batch_size = 5
 
-# Hail's default interval strategy + target number of 'records' (variants) per interval is very low, leading to a high
-# level of fragmentation. Instead of accepting those irritating constraints we provide our own intervals, and overwrite
-# default arguments like target_records which would override those and deliver high partition counts
-target_records = 30000000
+# Hail combining takes pre-set intervals when reading gVCF data, but ignores them for the final write
+# when VDSs are merged, the final partitioning is only determined by target_records
+# https://github.com/populationgenomics/hail/blob/main/hail/python/hail/vds/combiner/combine.py#L537
+target_records = 600000
 
 # if the process will remove a large number of SGs from the combiner, require this config setting to confirm intent
 sg_remove_threshold = 20
@@ -49,8 +49,8 @@ exome = 'gs://cpg-seqr-main/exome_based_intervals/100_var_balanced_intervals.bed
 genome = 'gs://cpg-seqr-main/genome_based_intervals/1000_var_balanced_intervals.bed'
 
 [combiner.vds_intervals]
-exome = 'gs://cpg-seqr-main/exome_based_intervals/2000_var_balanced_intervals.bed'
-genome = 'gs://cpg-seqr-main/genome_based_intervals/5000_var_balanced_intervals.bed'
+exome = 'gs://cpg-seqr-main/exome_based_intervals/500_var_balanced_intervals.bed'
+genome = 'gs://cpg-seqr-main/genome_based_intervals/2000_var_balanced_intervals.bed'
 
 [annotate_dataset]
 # highem, standard, or a string, e.g. "4Gi"

--- a/src/cpg_seqr_loader/config_template.toml
+++ b/src/cpg_seqr_loader/config_template.toml
@@ -50,7 +50,7 @@ genome = 'gs://cpg-seqr-main/genome_based_intervals/1000_var_balanced_intervals.
 
 [combiner.vds_intervals]
 exome = 'gs://cpg-seqr-main/exome_based_intervals/500_var_balanced_intervals.bed'
-genome = 'gs://cpg-seqr-main/genome_based_intervals/2000_var_balanced_intervals.bed'
+genome = 'gs://cpg-seqr-main/genome_based_intervals/5000_var_balanced_intervals.bed'
 
 [annotate_dataset]
 # highem, standard, or a string, e.g. "4Gi"

--- a/src/cpg_seqr_loader/scripts/densify_VDS_to_MT.py
+++ b/src/cpg_seqr_loader/scripts/densify_VDS_to_MT.py
@@ -127,9 +127,11 @@ def split_and_normalise(mt: hl.MatrixTable) -> hl.MatrixTable:
     mt = hl.split_multi_hts(mt)
 
     # adjust the AC field after splitting (not handled in split_multi, see method docstring)
-    mt = mt.annotate_rows(info=mt.info.annotate(AC=mt.info.AC[mt.a_index - 1]))
+    return mt.annotate_rows(info=mt.info.annotate(AC=mt.info.AC[mt.a_index - 1]))
 
-    # find the minimal representation for each variant
+
+def re_key_with_minrep(mt: hl.MatrixTable) -> hl.MatrixTable:
+    """Find the minimal representation for each variant."""
     mt = mt.annotate_rows(minrep=hl.min_rep(mt.locus, mt.alleles))
 
     # rotate the table key(s)
@@ -184,6 +186,10 @@ def main(
 
         # run splitting and normalisation
         mt = split_and_normalise(mt)
+
+        mt = mt.checkpoint(checkpoint_path.removesuffix('.mt') + '_before_rekey.mt', overwrite=True)
+
+        mt = re_key_with_minrep(mt)
 
         loguru.logger.info(f'Writing fresh data into {dense_mt_out}')
         mt.write(dense_mt_out, overwrite=True)

--- a/src/cpg_seqr_loader/scripts/run_combiner.py
+++ b/src/cpg_seqr_loader/scripts/run_combiner.py
@@ -152,7 +152,7 @@ def main(
         force=force_new_combiner,
         intervals=vds_intervals,
         branch_factor=config.config_retrieve(['combiner', 'branch_factor']),
-         target_records=config.config_retrieve(['combiner', 'target_records']),
+        target_records=config.config_retrieve(['combiner', 'target_records']),
         gvcf_batch_size=config.config_retrieve(['combiner', 'gvcf_batch_size']),
     ).run()
 

--- a/src/cpg_seqr_loader/scripts/run_combiner.py
+++ b/src/cpg_seqr_loader/scripts/run_combiner.py
@@ -152,9 +152,7 @@ def main(
         force=force_new_combiner,
         intervals=vds_intervals,
         branch_factor=config.config_retrieve(['combiner', 'branch_factor']),
-        target_records=config.config_retrieve(
-            ['combiner', 'target_records']
-        ),  # keep this high to prevent hail overriding preset partitions
+         target_records=config.config_retrieve(['combiner', 'target_records']),
         gvcf_batch_size=config.config_retrieve(['combiner', 'gvcf_batch_size']),
     ).run()
 


### PR DESCRIPTION
# Purpose

  - The combiner is broken due to interval shenennigans

## Proposed Changes

  - Decrease target_records. This _is_ used to determine VDS intervals (see link in code). By giving a crazy high number it's requesting broad partitions (only 96 partitions in an 8k sample callset). This hasn't been fatal for the pipeline, but is probably not what we want.
  - Add a second checkpoint in the densification script after INFO annotation/splitting, but before minrep/re-key. One thing I didn't consider was that the minrep call + key_by to swap the locus + alleles is triggering a full shuffle-sort of the whole table. This shuffle sort occurs after heavy INFO operations, and allelic splitting. Adding a checkpoint here should consolidate all the annotations, before doing a re-key on a freshly read matrixtable