### PR TITLE
Reset densification to previous working state

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM australia-southeast1-docker.pkg.dev/cpg-common/images/cpg_hail_gcloud:0.2.138.cpg1-1
 
 ENV PYTHONDONTWRITEBYTECODE=1
-ENV VERSION=0.2.2
+ENV VERSION=0.2.3
 
 WORKDIR /cpg_seqr_loader
 

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ CPG-Flow workflows are operated entirely by defining input Cohorts (see [here](h
 ```bash
 analysis-runner \
     --skip-repo-checkout \
-    --image australia-southeast1-docker.pkg.dev/cpg-common/images/cpg-flow-seqr-loader:0.2.2-1 \
+    --image australia-southeast1-docker.pkg.dev/cpg-common/images/cpg-flow-seqr-loader:0.2.3-1 \
     --config src/cpg_seqr_loader/config_template.toml \
     --config cohorts.toml \  # containing the inputs_cohorts and sequencing_type
     --dataset seqr \
@@ -70,7 +70,7 @@ analysis-runner \
 ```bash
 analysis-runner \
     --skip-repo-checkout \
-    --image australia-southeast1-docker.pkg.dev/cpg-common/images/cpg-flow-seqr-loader:0.2.2-1 \
+    --image australia-southeast1-docker.pkg.dev/cpg-common/images/cpg-flow-seqr-loader:0.2.3-1 \
     --config src/cpg_seqr_loader/config_template.toml \
     --config cohorts.toml \  # containing the inputs_cohorts and sequencing_type
     --dataset seqr \

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ description='Seqr-Loader (gVCF-combiner) implemented in CPG-Flow'
 readme = "README.md"
 # currently cpg-flow is pinned to this version
 requires-python = ">=3.10,<3.12"
-version="0.2.2"
+version="0.2.3"
 license={"file" = "LICENSE"}
 classifiers=[
     'Environment :: Console',
@@ -120,7 +120,7 @@ hail = ["hail"]
 "src/cpg_seqr_loader/scripts/annotate_cohort.py" = ["E501"]
 
 [tool.bumpversion]
-current_version = "0.2.2"
+current_version = "0.2.3"
 parse = "(?P<major>\\d+)\\.(?P<minor>\\d+)\\.(?P<patch>\\d+)"
 serialize = ["{major}.{minor}.{patch}"]
 commit = true

--- a/src/cpg_seqr_loader/config_template.toml
+++ b/src/cpg_seqr_loader/config_template.toml
@@ -45,10 +45,12 @@ sg_remove_threshold = 20
 sg_remove_confirm = false
 
 [combiner.densify_intervals]
+# these enforce partitioning on the VDS when it's read, so the intervals remain for the resulting MT
 exome = 'gs://cpg-seqr-main/exome_based_intervals/100_var_balanced_intervals.bed'
-genome = 'gs://cpg-seqr-main/genome_based_intervals/1000_var_balanced_intervals.bed'
+genome = 'gs://cpg-seqr-main/genome_based_intervals/2000_var_balanced_intervals.bed'
 
 [combiner.vds_intervals]
+# these intervals are used to partition incoming gVCFs, but don't shape the final VDS
 exome = 'gs://cpg-seqr-main/exome_based_intervals/500_var_balanced_intervals.bed'
 genome = 'gs://cpg-seqr-main/genome_based_intervals/5000_var_balanced_intervals.bed'
 

--- a/src/cpg_seqr_loader/scripts/densify_VDS_to_MT.py
+++ b/src/cpg_seqr_loader/scripts/densify_VDS_to_MT.py
@@ -124,7 +124,7 @@ def main(
         # annotate this info back into the main MatrixTable
         mt = mt.annotate_rows(info=info_ht[mt.row_key].info)
 
-        # unpack mt.info.info back into mt.info. Must be better syntax for this?
+        # drop the original gVCF-specific row field now that the computed INFO struct is attached
         mt = mt.drop('gvcf_info')
 
         loguru.logger.info('Splitting multiallelics, in a sparse way')

--- a/src/cpg_seqr_loader/scripts/densify_VDS_to_MT.py
+++ b/src/cpg_seqr_loader/scripts/densify_VDS_to_MT.py
@@ -93,7 +93,7 @@ def main(
         driver_cores=config.config_retrieve(['combiner', 'driver_cores']),
     )
 
-    # check here to see if we can reuse the dense MT, and we only need to generate VCFs
+    # check here to see if we can reuse the dense MT, and we only need to export as VCF representations
     if not utils.can_reuse(dense_mt_out):
         # generate a deterministic path to a post-densification checkpoint
         dense_checkpoint_path = checkpoint_path.removesuffix('.mt') + '_initial_densification.mt'

--- a/src/cpg_seqr_loader/scripts/densify_VDS_to_MT.py
+++ b/src/cpg_seqr_loader/scripts/densify_VDS_to_MT.py
@@ -99,7 +99,7 @@ def main(
         dense_checkpoint_path = checkpoint_path.removesuffix('.mt') + '_initial_densification.mt'
 
         # and check if it already exists
-        if utils.can_reuse(checkpoint_path):
+        if utils.can_reuse(dense_checkpoint_path):
             loguru.logger.info(f'Resuming from a densified checkpoint: {dense_checkpoint_path}')
             mt = hl.read_matrix_table(dense_checkpoint_path)
 

--- a/src/cpg_seqr_loader/scripts/densify_VDS_to_MT.py
+++ b/src/cpg_seqr_loader/scripts/densify_VDS_to_MT.py
@@ -4,6 +4,7 @@ densifies the VDS into a MatrixTable
 Writes the MT to the output path
 
 Additional arguments:
+    --checkpoint: where to write a checkpoint after the densification, prior to attribute annotation & splitting
     --sites_only: optional, if used write a sites-only VCF directory to this location
                   it's far more efficient for Hail to write out a VCF per-partition, rather than a single VCF
                   this also prevents the need for writing out a single VCF, then fragmenting that to run VEP, VQSR
@@ -63,84 +64,6 @@ def densify(vds_path: str, checkpoint_path: str) -> hl.MatrixTable:
     return mt.checkpoint(checkpoint_path, overwrite=True)
 
 
-def generate_mt_info(mt: hl.MatrixTable) -> hl.MatrixTable:
-    """
-    Applies all the methods to generate GATK-similar INFO attributes on a Combined VDS -> MT.
-
-    Args:
-        mt: MatrixTable
-
-    Returns:
-        annotated MatrixTable
-    """
-    # content shared with large_cohort.site_only_vcf.py
-    info_ht = default_compute_info(mt, site_annotations=True, n_partitions=mt.n_partitions())
-    info_ht = info_ht.annotate(info=info_ht.info.annotate(DP=mt.rows()[info_ht.key].site_dp))
-
-    info_ht = adjust_vcf_incompatible_types(
-        info_ht,
-        # with default INFO_VCF_AS_PIPE_DELIMITED_FIELDS, AS_VarDP will be converted
-        # into a pipe-delimited value e.g.: VarDP=|132.1|140.2
-        # which breaks VQSR parser (it doesn't recognise the delimiter and treats
-        # it as an array with a single string value "|132.1|140.2", leading to
-        # an IndexOutOfBound exception when trying to access value for second allele)
-        pipe_delimited_annotations=[],
-    )
-
-    # annotate with densified representations
-    mt = mt.annotate_entries(
-        GT=hl.vds.lgt_to_gt(mt.LGT, mt.LA),
-        AD=hl.vds.local_to_global(
-            mt.LAD,
-            mt.LA,
-            n_alleles=hl.len(mt.alleles),
-            fill_value=0,
-            number='R',
-        ),
-        PL=hl.vds.local_to_global(
-            mt.LPL,
-            mt.LA,
-            n_alleles=hl.len(mt.alleles),
-            fill_value=999,
-            number='G',
-        ),
-    )
-
-    mt = mt.drop('gvcf_info')
-
-    # annotate this info back into the main MatrixTable
-    return mt.annotate_rows(info=info_ht[mt.row_key].info)
-
-
-def split_and_normalise(mt: hl.MatrixTable) -> hl.MatrixTable:
-    """
-    Runs the multiallelic splitting, and variant representation normalisation process.
-
-    Args:
-        mt: MatrixTable
-
-    Returns:
-        the same MT data, with normalised and minimally-represented variants
-    """
-
-    # split out multiallelic rows on the dense representation
-    mt = hl.split_multi_hts(mt)
-
-    # adjust the AC field after splitting (not handled in split_multi, see method docstring)
-    return mt.annotate_rows(info=mt.info.annotate(AC=mt.info.AC[mt.a_index - 1]))
-
-
-def re_key_with_minrep(mt: hl.MatrixTable) -> hl.MatrixTable:
-    """Find the minimal representation for each variant."""
-    mt = mt.annotate_rows(minrep=hl.min_rep(mt.locus, mt.alleles))
-
-    # rotate the table key(s)
-    return mt.key_rows_by(
-        locus=mt.minrep.locus,
-        alleles=mt.minrep.alleles,
-    )
-
-
 def main(
     vds_in: str,
     dense_mt_out: str,
@@ -164,32 +87,48 @@ def main(
     """
 
     hail_batch.init_batch(
-        worker_memory=config.config_retrieve(['combiner', 'worker_memory'], 'highmem'),
-        worker_cores=config.config_retrieve(['combiner', 'worker_cores'], 1),
-        driver_memory=config.config_retrieve(['combiner', 'driver_memory'], 'highmem'),
-        driver_cores=config.config_retrieve(['combiner', 'driver_cores'], 2),
+        worker_memory=config.config_retrieve(['combiner', 'worker_memory']),
+        worker_cores=config.config_retrieve(['combiner', 'worker_cores']),
+        driver_memory=config.config_retrieve(['combiner', 'driver_memory']),
+        driver_cores=config.config_retrieve(['combiner', 'driver_cores']),
     )
 
-    # check here to see if we can reuse the dense MT
+    # check here to see if we can reuse the dense MT, and we only need to generate VCFs
     if not utils.can_reuse(dense_mt_out):
-        # and check here to see if we can re-use the checkpoint
+        # generate a deterministic path to a post-densification checkpoint
+        dense_checkpoint_path = checkpoint_path.removesuffix('.mt') + '_initial_densification.mt'
+
+        # and check if it already exists
         if utils.can_reuse(checkpoint_path):
-            loguru.logger.info(f'Resuming from a densified checkpoint: {checkpoint_path}')
-            mt = hl.read_matrix_table(checkpoint_path)
+            loguru.logger.info(f'Resuming from a densified checkpoint: {dense_checkpoint_path}')
+            mt = hl.read_matrix_table(dense_checkpoint_path)
 
         else:
-            loguru.logger.info(f'Running a VDS -> with densification, checkpointing to {checkpoint_path}')
-            mt = densify(vds_in, checkpoint_path)
+            loguru.logger.info(f'Running a VDS -> with densification, checkpointing to {dense_checkpoint_path}')
+            mt = densify(vds_in, dense_checkpoint_path)
 
-        # run the INFO field generation/annotation process
-        mt = generate_mt_info(mt)
+        # content shared with large_cohort.site_only_vcf.py
+        info_ht = default_compute_info(mt, site_annotations=True, n_partitions=mt.n_partitions())
+        info_ht = info_ht.annotate(info=info_ht.info.annotate(DP=mt.rows()[info_ht.key].site_dp))
 
-        # run splitting and normalisation
-        mt = split_and_normalise(mt)
+        info_ht = adjust_vcf_incompatible_types(
+            info_ht,
+            # with default INFO_VCF_AS_PIPE_DELIMITED_FIELDS, AS_VarDP will be converted
+            # into a pipe-delimited value e.g.: VarDP=|132.1|140.2
+            # which breaks VQSR parser (it doesn't recognise the delimiter and treats
+            # it as an array with a single string value "|132.1|140.2", leading to
+            # an IndexOutOfBound exception when trying to access value for second allele)
+            pipe_delimited_annotations=[],
+        )
 
-        mt = mt.checkpoint(checkpoint_path.removesuffix('.mt') + '_before_rekey.mt', overwrite=True)
+        # annotate this info back into the main MatrixTable
+        mt = mt.annotate_rows(info=info_ht[mt.row_key].info)
 
-        mt = re_key_with_minrep(mt)
+        # unpack mt.info.info back into mt.info. Must be better syntax for this?
+        mt = mt.drop('gvcf_info')
+
+        loguru.logger.info('Splitting multiallelics, in a sparse way')
+        mt = hl.experimental.sparse_split_multi(mt)
 
         loguru.logger.info(f'Writing fresh data into {dense_mt_out}')
         mt.write(dense_mt_out, overwrite=True)


### PR DESCRIPTION
# Purpose

  - Re-set the densification script to previous working state
  - see https://centrepopgen.slack.com/archives/C082NA58R7S/p1779061453418199
  - see diff https://github.com/populationgenomics/cpg-flow-seqr-loader/compare/a48dfcf9315c67b37b93361afd91ec6469ae0894..3848cc6852edb2fb89f191ea35021ed90ce7a5da

## Proposed Changes

  - Mostly reverts the code back to a working state, using experimental split_multi instead of re-annotating entries and splitting the dense representation
  - Retains the curated intervals logic to read the incoming VDS with pre-set partitions
  - Renames the checkpoint to prevent resumption from old workflow

retained change: the densification is done in a standalone method, but code is identical to the earlier version

## Hope

  - If this doesn't work, we're looking at the Hail 0.2.137 -> 0.2.138 change as the final culprit?