### PR TITLE
Add sample refresh mechanic

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM australia-southeast1-docker.pkg.dev/cpg-common/images/cpg_hail_gcloud:0.2.138.cpg1-1
 
 ENV PYTHONDONTWRITEBYTECODE=1
-ENV VERSION=0.2.5
+ENV VERSION=0.2.6
 
 WORKDIR /cpg_seqr_loader
 

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ CPG-Flow workflows are operated entirely by defining input Cohorts (see [here](h
 ```bash
 analysis-runner \
     --skip-repo-checkout \
-    --image australia-southeast1-docker.pkg.dev/cpg-common/images/cpg-flow-seqr-loader:0.2.5-1 \
+    --image australia-southeast1-docker.pkg.dev/cpg-common/images/cpg-flow-seqr-loader:0.2.6-1 \
     --config src/cpg_seqr_loader/config_template.toml \
     --config cohorts.toml \  # containing the inputs_cohorts and sequencing_type
     --dataset seqr \
@@ -70,7 +70,7 @@ analysis-runner \
 ```bash
 analysis-runner \
     --skip-repo-checkout \
-    --image australia-southeast1-docker.pkg.dev/cpg-common/images/cpg-flow-seqr-loader:0.2.5-1 \
+    --image australia-southeast1-docker.pkg.dev/cpg-common/images/cpg-flow-seqr-loader:0.2.6-1 \
     --config src/cpg_seqr_loader/config_template.toml \
     --config cohorts.toml \  # containing the inputs_cohorts and sequencing_type
     --dataset seqr \

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ description='Seqr-Loader (gVCF-combiner) implemented in CPG-Flow'
 readme = "README.md"
 # currently cpg-flow is pinned to this version
 requires-python = ">=3.10,<3.12"
-version="0.2.5"
+version="0.2.6"
 license={"file" = "LICENSE"}
 classifiers=[
     'Environment :: Console',
@@ -120,7 +120,7 @@ hail = ["hail"]
 "src/cpg_seqr_loader/scripts/annotate_cohort.py" = ["E501"]
 
 [tool.bumpversion]
-current_version = "0.2.5"
+current_version = "0.2.6"
 parse = "(?P<major>\\d+)\\.(?P<minor>\\d+)\\.(?P<patch>\\d+)"
 serialize = ["{major}.{minor}.{patch}"]
 commit = true

--- a/src/cpg_seqr_loader/config_template.toml
+++ b/src/cpg_seqr_loader/config_template.toml
@@ -44,6 +44,10 @@ target_records = 600000
 sg_remove_threshold = 20
 sg_remove_confirm = false
 
+# optional, list of SG IDs. These will be removed from the current VDS if present, then readded
+# rarely used mechanic, allows component gVCFs to be removed and replaced in case of data issues
+refresh_sgids = []
+
 [combiner.densify_intervals]
 # these enforce partitioning on the VDS when it's read, so the intervals remain for the resulting MT
 exome = 'gs://cpg-seqr-main/exome_based_intervals/100_var_balanced_intervals.bed'
@@ -81,11 +85,11 @@ indel_filter_level = 99.0
 vqsr_training_fragments_per_job = 100
 vqsr_apply_fragments_per_job = 60
 indel_recal_disc_size = 100
-snps_recal_disc_size = 20
+snps_recal_disc_size = 50
 snps_gather_disc_size = 10
 
 [images]
-bcftools = "australia-southeast1-docker.pkg.dev/cpg-common/images/bcftools:1.22-1"
+bcftools = "australia-southeast1-docker.pkg.dev/cpg-common/images/bcftools:1.23-1"
 gatk = "australia-southeast1-docker.pkg.dev/cpg-common/images/gatk:4.6.2.0-1"
 vep = "australia-southeast1-docker.pkg.dev/cpg-common/images/vep:110.1-1"
 

--- a/src/cpg_seqr_loader/config_template.toml
+++ b/src/cpg_seqr_loader/config_template.toml
@@ -44,7 +44,7 @@ target_records = 600000
 sg_remove_threshold = 20
 sg_remove_confirm = false
 
-# optional, list of SG IDs. These will be removed from the current VDS if present, then readded
+# optional, list of SG IDs. These will be removed from the current VDS if present, then re-added
 # rarely used mechanic, allows component gVCFs to be removed and replaced in case of data issues
 refresh_sgids = []
 

--- a/src/cpg_seqr_loader/jobs/CombineGvcfsIntoVds.py
+++ b/src/cpg_seqr_loader/jobs/CombineGvcfsIntoVds.py
@@ -42,7 +42,7 @@ def check_for_sample_removal(
         return ''
 
     loguru.logger.info(f'Planning to remove {len(sgs_to_remove)} SGs from current VDS.')
-    loguru.logger.info(f'SGs to remove: {sgs_to_remove}')
+    loguru.logger.info(f'SGs to remove: {sorted(sgs_to_remove)}')
 
     # make a temp file containing these IDs, and write them to it
     sg_remove_file = temp_dir / 'sgs_to_remove.txt'

--- a/src/cpg_seqr_loader/jobs/CombineGvcfsIntoVds.py
+++ b/src/cpg_seqr_loader/jobs/CombineGvcfsIntoVds.py
@@ -18,7 +18,7 @@ def check_for_sample_removal(
     temp_dir: Path,
 ) -> str:
     """
-    Contain all the logic for working out when samples need to be manually removed.
+    Contains all the logic for working out when samples need to be manually removed.
     - detect SG IDs to remove
     - write those to a temp file
     - pass into the combiner job
@@ -94,7 +94,7 @@ def create_combiner_jobs(
         sg_ids_in_vds = utils.manually_find_ids_from_vds(vds_path)
 
     # list of CPG IDs to remove, and re-add
-    refresh_sg_ids = set(config.config_retrieve(['workflow', 'refresh_sgids'], []))
+    refresh_sg_ids = set(config.config_retrieve(['combiner', 'refresh_sgids'], []))
     if refresh_sg_ids:
         loguru.logger.info(f'Samples to be refreshed from config: {refresh_sg_ids}')
 

--- a/src/cpg_seqr_loader/jobs/CombineGvcfsIntoVds.py
+++ b/src/cpg_seqr_loader/jobs/CombineGvcfsIntoVds.py
@@ -53,7 +53,7 @@ def create_combiner_jobs(
         sg_ids_in_vds = utils.manually_find_ids_from_vds(vds_path)
 
     # list of CPG IDs to remove, and re-add
-    refresh_gvcfs = config.config_retrieve(['workflow', 'refresh_gvcfs'], [])
+    refresh_gvcfs = config.config_retrieve(['workflow', 'refresh_sgids'], [])
 
     new_sg_gvcfs = [
         str(sg.gvcf)

--- a/src/cpg_seqr_loader/jobs/CombineGvcfsIntoVds.py
+++ b/src/cpg_seqr_loader/jobs/CombineGvcfsIntoVds.py
@@ -53,7 +53,7 @@ def create_combiner_jobs(
         sg_ids_in_vds = utils.manually_find_ids_from_vds(vds_path)
 
     # list of CPG IDs to remove, and re-add
-    refresh_gvcfs = config.config_retrieve(['workflow', 'refresh_sgids'], [])
+    refresh_gvcfs = set(config.config_retrieve(['workflow', 'refresh_sgids'], []))
 
     new_sg_gvcfs = [
         str(sg.gvcf)

--- a/src/cpg_seqr_loader/jobs/CombineGvcfsIntoVds.py
+++ b/src/cpg_seqr_loader/jobs/CombineGvcfsIntoVds.py
@@ -11,6 +11,48 @@ if TYPE_CHECKING:
     from hailtop.batch.job import BashJob
 
 
+def check_for_sample_removal(
+    sg_ids_in_vds: set[str],
+    sg_ids_in_mc: list[str],
+    refresh_sgs: set[str],
+    temp_dir: Path,
+) -> str:
+    """
+    Contain all the logic for working out when samples need to be manually removed.
+    - detect SG IDs to remove
+    - write those to a temp file
+    - pass into the combiner job
+    - return as an argument for the combiner script, or an empty string
+    """
+
+    if not sg_ids_in_vds:
+        return ''
+
+    loguru.logger.info(f'Found {len(sg_ids_in_vds)} SG IDs in VDS.')
+    loguru.logger.info(f'Total {len(sg_ids_in_mc)} SGs in this MultiCohort.')
+
+    # gather any SGs to remove based on MultiCohort alone
+    sgs_to_remove = sg_ids_in_vds - set(sg_ids_in_mc)
+
+    # add any samples which need to be refreshed - union of available SGs and current SGs
+    # union: can't request removal of an SG not currently in the VDS
+    sgs_to_remove |= sg_ids_in_vds & refresh_sgs
+
+    if not sgs_to_remove:
+        return ''
+
+    loguru.logger.info(f'Planning to remove {len(sgs_to_remove)} SGs from current VDS.')
+    loguru.logger.info(f'SGs to remove: {sgs_to_remove}')
+
+    # make a temp file containing these IDs, and write them to it
+    sg_remove_file = temp_dir / 'sgs_to_remove.txt'
+    with sg_remove_file.open('w') as write_handle:
+        for sgid in sorted(sgs_to_remove):
+            write_handle.write(f'{sgid!s}\n')
+    localised_sg_remove_file = hail_batch.get_batch().read_input(sg_remove_file)
+    return f'--sg_remove_file {localised_sg_remove_file!s}'
+
+
 def create_combiner_jobs(
     multicohort: targets.MultiCohort,
     output_vds: Path,
@@ -20,7 +62,6 @@ def create_combiner_jobs(
 ) -> 'BashJob | None':
     vds_path: str | None = None
     sg_ids_in_vds: set[str] = set()
-    sgs_to_remove: list[str] = []
 
     temp_dir = to_path(temp_dir_string)
 
@@ -53,40 +94,35 @@ def create_combiner_jobs(
         sg_ids_in_vds = utils.manually_find_ids_from_vds(vds_path)
 
     # list of CPG IDs to remove, and re-add
-    refresh_gvcfs = set(config.config_retrieve(['workflow', 'refresh_sgids'], []))
+    refresh_sg_ids = set(config.config_retrieve(['workflow', 'refresh_sgids'], []))
+    if refresh_sg_ids:
+        loguru.logger.info(f'Samples to be refreshed from config: {refresh_sg_ids}')
 
+    # all SGs in this multicohort
+    sgs_in_mc: list[str] = multicohort.get_sequencing_group_ids()
+
+    # check for refresh samples which don't exist in this multicohort - can't tolerate that situation
+    if refresh_missing := refresh_sg_ids - set(sgs_in_mc):
+        raise ValueError(f'Refresh requested for {refresh_missing} SG IDs - absent from this MultiCohort.')
+
+    # get all gVCF paths for samples which aren't already in the VDS, or samples we intend to refresh (remove, re-add)
     new_sg_gvcfs = [
         str(sg.gvcf)
         for sg in multicohort.get_sequencing_groups()
-        if (sg.gvcf is not None) and ((sg.id not in sg_ids_in_vds) or (sg.id in refresh_gvcfs))
+        if (sg.gvcf is not None) and ((sg.id not in sg_ids_in_vds) or (sg.id in refresh_sg_ids))
     ]
 
-    # final check - if we have a VDS, and we have a current MultiCohort
+    # final check - if we have a VDS, and we have a current MultiCohort, and optionally a list of samples to refresh
     # detect any samples which should be _removed_ from the current VDS prior to further combining taking place
-    sg_remove_arg = ''
-    if sg_ids_in_vds:
-        sgs_in_mc: list[str] = multicohort.get_sequencing_group_ids()
-        loguru.logger.info(f'Found {len(sg_ids_in_vds)} SG IDs in VDS {vds_path}')
-        loguru.logger.info(f'Total {len(sgs_in_mc)} SGs in this MultiCohort')
-        if refresh_gvcfs:
-            loguru.logger.info(f'Samples to be refreshed from config: {refresh_gvcfs}')
+    # return this as an argument for the combiner script
+    sg_remove_arg = check_for_sample_removal(
+        sg_ids_in_vds=sg_ids_in_vds,
+        sg_ids_in_mc=sgs_in_mc,
+        refresh_sgs=refresh_sg_ids,
+        temp_dir=temp_dir,
+    )
 
-        # gather any SGs to remove, adding any samples which need to be refreshed
-        sgs_to_remove = sorted((set(sg_ids_in_vds) - set(sgs_in_mc)) | refresh_gvcfs)
-
-        if sgs_to_remove:
-            loguru.logger.info(f'Removing {len(sgs_to_remove)} SGs from VDS {vds_path}')
-            loguru.logger.info(f'SGs to remove: {sgs_to_remove}')
-
-            # make a temp file containing these IDs, and write them to it
-            sg_remove_file = temp_dir / 'sgs_to_remove.txt'
-            with sg_remove_file.open('w') as write_handle:
-                for sgid in sgs_to_remove:
-                    write_handle.write(f'{sgid!s}\n')
-            localised_sg_remove_file = hail_batch.get_batch().read_input(sg_remove_file)
-            sg_remove_arg = f'--sg_remove_file {localised_sg_remove_file!s}'
-
-    if not (new_sg_gvcfs or sgs_to_remove):
+    if not (new_sg_gvcfs or sg_remove_arg):
         loguru.logger.info('No GVCFs to add to, or remove from, existing VDS')
         loguru.logger.info(f'Checking if VDS exists: {output_vds}: {output_vds.exists()}')
         return None

--- a/src/cpg_seqr_loader/jobs/CombineGvcfsIntoVds.py
+++ b/src/cpg_seqr_loader/jobs/CombineGvcfsIntoVds.py
@@ -52,10 +52,13 @@ def create_combiner_jobs(
     if vds_path and config.config_retrieve(['workflow', 'manually_check_vds_sg_ids']):
         sg_ids_in_vds = utils.manually_find_ids_from_vds(vds_path)
 
+    # list of CPG IDs to remove, and re-add
+    refresh_gvcfs = config.config_retrieve(['workflow', 'refresh_gvcfs'], [])
+
     new_sg_gvcfs = [
         str(sg.gvcf)
         for sg in multicohort.get_sequencing_groups()
-        if (sg.gvcf is not None) and (sg.id not in sg_ids_in_vds)
+        if (sg.gvcf is not None) and ((sg.id not in sg_ids_in_vds) or (sg.id in refresh_gvcfs))
     ]
 
     # final check - if we have a VDS, and we have a current MultiCohort
@@ -65,16 +68,17 @@ def create_combiner_jobs(
         sgs_in_mc: list[str] = multicohort.get_sequencing_group_ids()
         loguru.logger.info(f'Found {len(sg_ids_in_vds)} SG IDs in VDS {vds_path}')
         loguru.logger.info(f'Total {len(sgs_in_mc)} SGs in this MultiCohort')
+        if refresh_gvcfs:
+            loguru.logger.info(f'Samples to be refreshed from config: {refresh_gvcfs}')
 
-        sgs_to_remove = sorted(set(sg_ids_in_vds) - set(sgs_in_mc))
+        # gather any SGs to remove, adding any samples which need to be refreshed
+        sgs_to_remove = sorted((set(sg_ids_in_vds) - set(sgs_in_mc)) | refresh_gvcfs)
 
         if sgs_to_remove:
             loguru.logger.info(f'Removing {len(sgs_to_remove)} SGs from VDS {vds_path}')
             loguru.logger.info(f'SGs to remove: {sgs_to_remove}')
 
             # make a temp file containing these IDs, and write them to it
-
-            # write the gVCF paths into a temporary file
             sg_remove_file = temp_dir / 'sgs_to_remove.txt'
             with sg_remove_file.open('w') as write_handle:
                 for sgid in sgs_to_remove:


### PR DESCRIPTION
# Purpose

  - We may want to remove SGs from the current VDS, and combine new data containing a fixed version of the same sample's gVCF

n.b. this PR got longer. The core logic was pretty simple, but pushed the method complexity slightly too high for the linter, so it's been broken out as a separate method. [This](https://github.com/populationgenomics/cpg-flow-seqr-loader/compare/main..5bd2e20) was the concise version of the change before a big refactor.

## Proposed Changes

  - add a new config entry containing samples to 'refresh'
  - refresh samples are retained as new input gVCFs even if they already exist in the VDS
  - refresh samples are also removed to the samples to remove
  - during combining they are first removed, then re-added

## Restructured

The linter was (rightfully) complaining about the method in this script being too complicated - I've pulled out all the sample removal logic into a separate method:
  - take the SGs in the multicohort, the VDS, and the list to refresh
  - if any samples are in the VDS but not the multicohort, we remove
  - add any samples in the VDS and the refresh list
  - if any samples need to be removed, write a temp file and return the formatted string `--sg_remove_file {path}`
  - if no samples need to be removed, return an empty string

## Safeguarding

  - samples which are in the multicohort, requested for a 'refresh', but aren't in the VDS - don't schedule for removal
  - samples with a refresh requested but not in the multicohort - raise exception

## Unrelated config

  - uses bcftools 1.23.1, contains lots of htslib bugfixes [notes](https://github.com/samtools/bcftools/releases)
  - increase standard VM provision for VQSR indels, was required locally during last workflow run

## Checklist

- [x] Version Bump!
- [x] Related GitHub Issue created
- [ ] Tests covering new change
- [x] Linting checks pass
