### PR TITLE
Annotate dataset into temp

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM australia-southeast1-docker.pkg.dev/cpg-common/images/cpg_hail_gcloud:0.2.138.cpg1-1
 
 ENV PYTHONDONTWRITEBYTECODE=1
-ENV VERSION=0.2.6
+ENV VERSION=0.2.7
 
 WORKDIR /cpg_seqr_loader
 

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ CPG-Flow workflows are operated entirely by defining input Cohorts (see [here](h
 ```bash
 analysis-runner \
     --skip-repo-checkout \
-    --image australia-southeast1-docker.pkg.dev/cpg-common/images/cpg-flow-seqr-loader:0.2.6-1 \
+    --image australia-southeast1-docker.pkg.dev/cpg-common/images/cpg-flow-seqr-loader:0.2.7-1 \
     --config src/cpg_seqr_loader/config_template.toml \
     --config cohorts.toml \  # containing the inputs_cohorts and sequencing_type
     --dataset seqr \
@@ -70,7 +70,7 @@ analysis-runner \
 ```bash
 analysis-runner \
     --skip-repo-checkout \
-    --image australia-southeast1-docker.pkg.dev/cpg-common/images/cpg-flow-seqr-loader:0.2.6-1 \
+    --image australia-southeast1-docker.pkg.dev/cpg-common/images/cpg-flow-seqr-loader:0.2.7-1 \
     --config src/cpg_seqr_loader/config_template.toml \
     --config cohorts.toml \  # containing the inputs_cohorts and sequencing_type
     --dataset seqr \

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ description='Seqr-Loader (gVCF-combiner) implemented in CPG-Flow'
 readme = "README.md"
 # currently cpg-flow is pinned to this version
 requires-python = ">=3.10,<3.12"
-version="0.2.6"
+version="0.2.7"
 license={"file" = "LICENSE"}
 classifiers=[
     'Environment :: Console',
@@ -120,7 +120,7 @@ hail = ["hail"]
 "src/cpg_seqr_loader/scripts/annotate_cohort.py" = ["E501"]
 
 [tool.bumpversion]
-current_version = "0.2.6"
+current_version = "0.2.7"
 parse = "(?P<major>\\d+)\\.(?P<minor>\\d+)\\.(?P<patch>\\d+)"
 serialize = ["{major}.{minor}.{patch}"]
 commit = true

--- a/src/cpg_seqr_loader/jobs/AnnotateDataset.py
+++ b/src/cpg_seqr_loader/jobs/AnnotateDataset.py
@@ -9,7 +9,7 @@ if TYPE_CHECKING:
 
 def create_annotate_dataset_job(
     dataset: targets.Dataset,
-    input_mt: str,
+    input_mt: Path,
     output_mt: Path,
     job_attrs: dict[str, str],
 ) -> 'BashJob':
@@ -25,7 +25,7 @@ def create_annotate_dataset_job(
     job.command(
         f"""
         python -m cpg_seqr_loader.scripts.annotate_dataset \\
-            --input {input_mt} \\
+            --input {input_mt!s} \\
             --output {output_mt!s}
         """
     )

--- a/src/cpg_seqr_loader/stages.py
+++ b/src/cpg_seqr_loader/stages.py
@@ -484,8 +484,6 @@ class SubsetMtToDatasetWithHail(stage.DatasetStage):
         AnnotateCohort,
         SubsetMtToDatasetWithHail,
     ],
-    # analyses recorded to pass through to Metamist/other workflows
-    analysis_type='matrixtable',
 )
 class AnnotateDataset(stage.DatasetStage):
     def expected_outputs(self, dataset: targets.Dataset) -> Path:
@@ -498,7 +496,7 @@ class AnnotateDataset(stage.DatasetStage):
             mt_name = f'{dataset.name}.mt'
 
         return (
-            dataset.prefix()
+            dataset.tmp_prefix()
             / workflow.get_workflow().name
             / workflow.get_workflow().output_version
             / self.name


### PR DESCRIPTION
# Purpose

  - Now we only have Seqr as a downstream consumer of this stage, and that's done via the ES Index representation. We don't need this MT to be in permanent storage
  - This is very low priority, or we can just leave as-is

## Checklist

- [ ] Version Bump!
- [ ] Related GitHub Issue created
- [ ] Tests covering new change
- [ ] Linting checks pass
