### PR TITLE
Fail if sgids missing gvcfs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM australia-southeast1-docker.pkg.dev/cpg-common/images/cpg_hail_gcloud:0.2.138.cpg1-1
 
 ENV PYTHONDONTWRITEBYTECODE=1
-ENV VERSION=0.2.7
+ENV VERSION=0.2.8
 
 WORKDIR /cpg_seqr_loader
 

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ CPG-Flow workflows are operated entirely by defining input Cohorts (see [here](h
 ```bash
 analysis-runner \
     --skip-repo-checkout \
-    --image australia-southeast1-docker.pkg.dev/cpg-common/images/cpg-flow-seqr-loader:0.2.7-1 \
+    --image australia-southeast1-docker.pkg.dev/cpg-common/images/cpg-flow-seqr-loader:0.2.8-1 \
     --config src/cpg_seqr_loader/config_template.toml \
     --config cohorts.toml \  # containing the inputs_cohorts and sequencing_type
     --dataset seqr \
@@ -70,7 +70,7 @@ analysis-runner \
 ```bash
 analysis-runner \
     --skip-repo-checkout \
-    --image australia-southeast1-docker.pkg.dev/cpg-common/images/cpg-flow-seqr-loader:0.2.7-1 \
+    --image australia-southeast1-docker.pkg.dev/cpg-common/images/cpg-flow-seqr-loader:0.2.8-1 \
     --config src/cpg_seqr_loader/config_template.toml \
     --config cohorts.toml \  # containing the inputs_cohorts and sequencing_type
     --dataset seqr \

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ description='Seqr-Loader (gVCF-combiner) implemented in CPG-Flow'
 readme = "README.md"
 # currently cpg-flow is pinned to this version
 requires-python = ">=3.10,<3.12"
-version="0.2.7"
+version="0.2.8"
 license={"file" = "LICENSE"}
 classifiers=[
     'Environment :: Console',
@@ -120,7 +120,7 @@ hail = ["hail"]
 "src/cpg_seqr_loader/scripts/annotate_cohort.py" = ["E501"]
 
 [tool.bumpversion]
-current_version = "0.2.7"
+current_version = "0.2.8"
 parse = "(?P<major>\\d+)\\.(?P<minor>\\d+)\\.(?P<patch>\\d+)"
 serialize = ["{major}.{minor}.{patch}"]
 commit = true

--- a/src/cpg_seqr_loader/jobs/CombineGvcfsIntoVds.py
+++ b/src/cpg_seqr_loader/jobs/CombineGvcfsIntoVds.py
@@ -109,7 +109,7 @@ def create_combiner_jobs(
     new_sg_gvcfs = [
         str(sg.gvcf)
         for sg in multicohort.get_sequencing_groups()
-        if (sg.gvcf is not None) and ((sg.id not in sg_ids_in_vds) or (sg.id in refresh_sg_ids))
+        if (sg.id not in sg_ids_in_vds) or (sg.id in refresh_sg_ids)
     ]
 
     # final check - if we have a VDS, and we have a current MultiCohort, and optionally a list of samples to refresh

--- a/src/cpg_seqr_loader/stages.py
+++ b/src/cpg_seqr_loader/stages.py
@@ -41,6 +41,10 @@ class CombineGvcfsIntoVds(stage.MultiCohortStage):
     def queue_jobs(self, multicohort: targets.MultiCohort, inputs: stage.StageInput) -> stage.StageOutput:
         outputs = self.expected_outputs(multicohort)
 
+        # refuse to run the combiner where input SGs lack a gVCF and would be silently removed
+        if no_vcf_sgs := [sg.id for sg in multicohort.get_sequencing_groups() if sg.gvcf is None]:
+            raise ValueError(f'SG IDs lacking gVCFs present in multicohort: {",".join(no_vcf_sgs)})')
+
         job = create_combiner_jobs(
             multicohort=multicohort,
             output_vds=outputs['vds'],


### PR DESCRIPTION
# Purpose

  - Some SG IDs have been silently removed from analysis because they lacked gVCFs

## Proposed Changes

  - Raises an error if any SG ID in the input cohorts lacks a gVCF, so cannot be combined
  - Removes silent skipping on any SG ID without a gVCF. Previously these were removed from the combiner input file

## Checklist

- [x] Version Bump!
- [ ] Related GitHub Issue created
- [ ] Tests covering new change
- [x] Linting checks pass
