### PR TITLE
Chain workflow after VCF export

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -18,7 +18,7 @@ jobs:
 
     - uses: actions/setup-python@v4
       with:
-        python-version: '3.10'
+        python-version: '3.11'
         cache: 'pip'
         cache-dependency-path: pyproject.toml
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,8 +1,8 @@
 default_language_version:
-  python: python3.10
+  python: python3.11
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.5.0
+    rev: v6.0.0
     hooks:
       - id: check-yaml
         exclude: '\.*conda/.*'

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM australia-southeast1-docker.pkg.dev/cpg-common/images/cpg_hail_gcloud:0.2.138.cpg1-1
 
 ENV PYTHONDONTWRITEBYTECODE=1
-ENV VERSION=0.2.9
+ENV VERSION=0.3.0
 
 WORKDIR /cpg_seqr_loader
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM australia-southeast1-docker.pkg.dev/cpg-common/images/cpg_hail_gcloud:0.2.138.cpg1-1
 
 ENV PYTHONDONTWRITEBYTECODE=1
-ENV VERSION=0.2.8
+ENV VERSION=0.2.9
 
 WORKDIR /cpg_seqr_loader
 

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ CPG-Flow workflows are operated entirely by defining input Cohorts (see [here](h
 ```bash
 analysis-runner \
     --skip-repo-checkout \
-    --image australia-southeast1-docker.pkg.dev/cpg-common/images/cpg-flow-seqr-loader:0.2.8-1 \
+    --image australia-southeast1-docker.pkg.dev/cpg-common/images/cpg-flow-seqr-loader:0.2.9-1 \
     --config src/cpg_seqr_loader/config_template.toml \
     --config cohorts.toml \  # containing the inputs_cohorts and sequencing_type
     --dataset seqr \
@@ -70,7 +70,7 @@ analysis-runner \
 ```bash
 analysis-runner \
     --skip-repo-checkout \
-    --image australia-southeast1-docker.pkg.dev/cpg-common/images/cpg-flow-seqr-loader:0.2.8-1 \
+    --image australia-southeast1-docker.pkg.dev/cpg-common/images/cpg-flow-seqr-loader:0.2.9-1 \
     --config src/cpg_seqr_loader/config_template.toml \
     --config cohorts.toml \  # containing the inputs_cohorts and sequencing_type
     --dataset seqr \

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ CPG-Flow workflows are operated entirely by defining input Cohorts (see [here](h
 ```bash
 analysis-runner \
     --skip-repo-checkout \
-    --image australia-southeast1-docker.pkg.dev/cpg-common/images/cpg-flow-seqr-loader:0.2.9-1 \
+    --image australia-southeast1-docker.pkg.dev/cpg-common/images/cpg-flow-seqr-loader:0.3.0-1 \
     --config src/cpg_seqr_loader/config_template.toml \
     --config cohorts.toml \  # containing the inputs_cohorts and sequencing_type
     --dataset seqr \
@@ -70,7 +70,7 @@ analysis-runner \
 ```bash
 analysis-runner \
     --skip-repo-checkout \
-    --image australia-southeast1-docker.pkg.dev/cpg-common/images/cpg-flow-seqr-loader:0.2.9-1 \
+    --image australia-southeast1-docker.pkg.dev/cpg-common/images/cpg-flow-seqr-loader:0.3.0-1 \
     --config src/cpg_seqr_loader/config_template.toml \
     --config cohorts.toml \  # containing the inputs_cohorts and sequencing_type
     --dataset seqr \

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ description='Seqr-Loader (gVCF-combiner) implemented in CPG-Flow'
 readme = "README.md"
 # currently cpg-flow is pinned to this version
 requires-python = ">=3.10,<3.12"
-version="0.2.9"
+version="0.3.0"
 license={"file" = "LICENSE"}
 classifiers=[
     'Environment :: Console',
@@ -121,7 +121,7 @@ hail = ["hail"]
 "src/cpg_seqr_loader/scripts/annotate_cohort.py" = ["E501"]
 
 [tool.bumpversion]
-current_version = "0.2.9"
+current_version = "0.3.0"
 parse = "(?P<major>\\d+)\\.(?P<minor>\\d+)\\.(?P<patch>\\d+)"
 serialize = ["{major}.{minor}.{patch}"]
 commit = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ description='Seqr-Loader (gVCF-combiner) implemented in CPG-Flow'
 readme = "README.md"
 # currently cpg-flow is pinned to this version
 requires-python = ">=3.10,<3.12"
-version="0.2.8"
+version="0.2.9"
 license={"file" = "LICENSE"}
 classifiers=[
     'Environment :: Console',
@@ -121,7 +121,7 @@ hail = ["hail"]
 "src/cpg_seqr_loader/scripts/annotate_cohort.py" = ["E501"]
 
 [tool.bumpversion]
-current_version = "0.2.8"
+current_version = "0.2.9"
 parse = "(?P<major>\\d+)\\.(?P<minor>\\d+)\\.(?P<patch>\\d+)"
 serialize = ["{major}.{minor}.{patch}"]
 commit = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,19 +53,6 @@ include_package_data = true
 [options.package_data]
 'cpg_seqr_loader'=  ['config_template.toml']
 
-[tool.black]
-line-length = 120
-skip-string-normalization = true
-exclude = '''
-/(
-  venv
-  | \.mypy_cache
-  | \.venv
-  | build
-  | dist
-)/
-'''
-
 [tool.mypy]
 ignore_missing_imports = true
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,7 @@ classifiers=[
 ]
 
 dependencies=[
+    'analysis-runner',
     'cpg-flow~=1.3',
     'elasticsearch==8.*',
 ]
@@ -108,7 +109,7 @@ ignore = [
 section-order = ["future", "standard-library", "third-party", "hail", "cpg", "first-party", "local-folder"]
 
 [tool.ruff.lint.isort.sections]
-cpg = ["cpg_seqr_loader", "talos", "cpg-flow", "cpg-utils"]
+cpg = ["analysis-runner", "cpg_flow", "cpg_utils"]
 hail = ["hail"]
 
 

--- a/src/cpg_seqr_loader/first_workflow.py
+++ b/src/cpg_seqr_loader/first_workflow.py
@@ -8,7 +8,7 @@ import argparse
 
 from cpg_flow import workflow
 
-from cpg_seqr_loader.stages import SubmitPostCombinerWorkflow, DeleteCombinerTemp
+from cpg_seqr_loader.stages import DeleteCombinerTemp, SubmitPostCombinerWorkflow
 
 
 def cli_main():

--- a/src/cpg_seqr_loader/first_workflow.py
+++ b/src/cpg_seqr_loader/first_workflow.py
@@ -8,7 +8,7 @@ import argparse
 
 from cpg_flow import workflow
 
-from cpg_seqr_loader.stages import CreateDenseMtFromVdsWithHail, DeleteCombinerTemp
+from cpg_seqr_loader.stages import SubmitPostCombinerWorkflow, DeleteCombinerTemp
 
 
 def cli_main():
@@ -18,7 +18,7 @@ def cli_main():
 
     workflow.run_workflow(
         name='seqr_loader',
-        stages=[DeleteCombinerTemp, CreateDenseMtFromVdsWithHail],
+        stages=[DeleteCombinerTemp, SubmitPostCombinerWorkflow],
         dry_run=args.dry_run,
     )
 

--- a/src/cpg_seqr_loader/jobs/ResubmitWorkflow.py
+++ b/src/cpg_seqr_loader/jobs/ResubmitWorkflow.py
@@ -1,7 +1,6 @@
 from typing import TYPE_CHECKING
 
-from cpg_utils import hail_batch, config
-
+from cpg_utils import config, hail_batch
 
 if TYPE_CHECKING:
     from hailtop.batch.job import PythonJob
@@ -11,13 +10,14 @@ def submission_python_job(output_path: str):
     """"""
     import toml
     from analysis_runner.cli_analysisrunner import run_analysis_runner
+
     from cpg_utils import config, to_path
 
     # make sure the config is loaded
     _ar = config.config_retrieve(['workflow', 'ar-guid'])
 
     # pop off any workflow-unique attributes
-    config_dict = dict(config._config)
+    config_dict = dict(config._config)  # noqa: SLF001
     _ar = config_dict['workflow'].pop('ar-guid')
 
     with open('config.toml', 'w') as config_file:

--- a/src/cpg_seqr_loader/jobs/ResubmitWorkflow.py
+++ b/src/cpg_seqr_loader/jobs/ResubmitWorkflow.py
@@ -1,0 +1,47 @@
+from typing import TYPE_CHECKING
+
+from cpg_utils import hail_batch, config
+
+
+if TYPE_CHECKING:
+    from hailtop.batch.job import PythonJob
+
+
+def submission_python_job(output_path: str):
+    """"""
+    import toml
+    from analysis_runner.cli_analysisrunner import run_analysis_runner
+    from cpg_utils import config, to_path
+
+    # make sure the config is loaded
+    _ar = config.config_retrieve(['workflow', 'ar-guid'])
+
+    # pop off any workflow-unique attributes
+    config_dict = dict(config._config)
+    _ar = config_dict['workflow'].pop('ar-guid')
+
+    with open('config.toml', 'w') as config_file:
+        config_file.write(toml.dumps(config_dict))
+
+    run_analysis_runner(
+        dataset=config_dict['workflow']['dataset'],
+        image=config_dict['workflow']['driver_image'],
+        output_dir='',
+        script=['full_workflow'],
+        description='',
+        access_level=config_dict['workflow']['access_level'],
+        config=['config.toml'],
+        skip_repo_checkout=True,
+    )
+
+    with to_path(output_path).open('w') as output_file:
+        output_file.write(toml.dumps(config_dict))
+
+
+def resubmit_full_workflow(output_path: str) -> 'PythonJob':
+    """Chain the second phase of the workflow using analysis-runner."""
+    batch_instance = hail_batch.get_batch()
+    npj = batch_instance.new_python_job('Submit second Seqr-Loader workflow phase.')
+    npj.image(config.config_retrieve(['workflow', 'driver_image']))
+    npj.call(submission_python_job, output_path)
+    return npj

--- a/src/cpg_seqr_loader/stages.py
+++ b/src/cpg_seqr_loader/stages.py
@@ -61,7 +61,7 @@ class CombineGvcfsIntoVds(stage.MultiCohortStage):
 class SubmitPostCombinerWorkflow(stage.MultiCohortStage):
     def expected_outputs(self, multicohort: targets.MultiCohort) -> dict[str, Path]:
         return {
-            'resubmit': self.prefix / f'{multicohort.name}_resubmitted.txt',
+            'resubmit': self.prefix / f'{multicohort.name}_resubmitted.toml',
         }
 
     def queue_jobs(self, multicohort: targets.MultiCohort, inputs: stage.StageInput) -> stage.StageOutput:

--- a/src/cpg_seqr_loader/stages.py
+++ b/src/cpg_seqr_loader/stages.py
@@ -20,6 +20,7 @@ from cpg_seqr_loader.jobs.CreateDenseMtFromVdsWithHail import generate_densify_j
 from cpg_seqr_loader.jobs.DeleteCombinerTemp import delete_temp_data_recursive
 from cpg_seqr_loader.jobs.ExportMtAsEsIndex import create_es_export_job
 from cpg_seqr_loader.jobs.GatherTrainedVqsrSnpTranches import gather_tranches
+from cpg_seqr_loader.jobs.ResubmitWorkflow import resubmit_full_workflow
 from cpg_seqr_loader.jobs.RunIndelVqsr import apply_recalibration_indels
 from cpg_seqr_loader.jobs.RunSnpVqsrOnFragments import apply_snp_vqsr_to_fragments
 from cpg_seqr_loader.jobs.SubsetMtToDatasetWithHail import create_subset_mt_job
@@ -52,6 +53,21 @@ class CombineGvcfsIntoVds(stage.MultiCohortStage):
             temp_dir_string=outputs['tmp'],
             job_attrs=self.get_job_attrs(multicohort),
         )
+        return self.make_outputs(multicohort, data=outputs, jobs=job)
+
+
+@stage.stage(required_stages=[CombineGvcfsIntoVds])
+class SubmitPostCombinerWorkflow(stage.MultiCohortStage):
+    def expected_outputs(self, multicohort: targets.MultiCohort) -> dict[str, Path]:
+        return {
+            'resubmit': self.prefix / f'{multicohort.name}_resubmitted.txt',
+        }
+
+    def queue_jobs(self, multicohort: targets.MultiCohort, inputs: stage.StageInput) -> stage.StageOutput:
+        outputs = self.expected_outputs(multicohort)
+
+        job = resubmit_full_workflow(str(outputs['resubmit']))
+
         return self.make_outputs(multicohort, data=outputs, jobs=job)
 
 


### PR DESCRIPTION
# Purpose

  - Self-contained attempt at a self-workflow submission
  - Should be help until #58 is merged in

## Proposed Changes

  - To overcome the lack of dynamic workflow planning in Hail Batch, the seqr-loader has to densify and export the VDS/MT as fragments, then a secondary workflow is submitted which can plan the workflow using the exact number of resulting fragments
  - New Stage to sit after the VCF export, submitting the latter half of the workflow using (almost) the same config

## Checklist

- [x] Version Bump!
- [x] Related GitHub Issue created
- [] Tests covering new change
- [x] Linting checks pass
