### PR TITLE
More robust ES export

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM australia-southeast1-docker.pkg.dev/cpg-common/images/cpg_hail_gcloud:0.2.138.cpg1-1
 
 ENV PYTHONDONTWRITEBYTECODE=1
-ENV VERSION=0.3.0
+ENV VERSION=0.3.1
 
 WORKDIR /cpg_seqr_loader
 

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ CPG-Flow workflows are operated entirely by defining input Cohorts (see [here](h
 ```bash
 analysis-runner \
     --skip-repo-checkout \
-    --image australia-southeast1-docker.pkg.dev/cpg-common/images/cpg-flow-seqr-loader:0.3.0-1 \
+    --image australia-southeast1-docker.pkg.dev/cpg-common/images/cpg-flow-seqr-loader:0.3.1-1 \
     --config src/cpg_seqr_loader/config_template.toml \
     --config cohorts.toml \  # containing the inputs_cohorts and sequencing_type
     --dataset seqr \
@@ -70,7 +70,7 @@ analysis-runner \
 ```bash
 analysis-runner \
     --skip-repo-checkout \
-    --image australia-southeast1-docker.pkg.dev/cpg-common/images/cpg-flow-seqr-loader:0.3.0-1 \
+    --image australia-southeast1-docker.pkg.dev/cpg-common/images/cpg-flow-seqr-loader:0.3.1-1 \
     --config src/cpg_seqr_loader/config_template.toml \
     --config cohorts.toml \  # containing the inputs_cohorts and sequencing_type
     --dataset seqr \

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ description='Seqr-Loader (gVCF-combiner) implemented in CPG-Flow'
 readme = "README.md"
 # currently cpg-flow is pinned to this version
 requires-python = ">=3.10,<3.12"
-version="0.3.0"
+version="0.3.1"
 license={"file" = "LICENSE"}
 classifiers=[
     'Environment :: Console',
@@ -108,7 +108,7 @@ hail = ["hail"]
 "src/cpg_seqr_loader/scripts/annotate_cohort.py" = ["E501"]
 
 [tool.bumpversion]
-current_version = "0.3.0"
+current_version = "0.3.1"
 parse = "(?P<major>\\d+)\\.(?P<minor>\\d+)\\.(?P<patch>\\d+)"
 serialize = ["{major}.{minor}.{patch}"]
 commit = true

--- a/src/cpg_seqr_loader/scripts/mt_to_es.py
+++ b/src/cpg_seqr_loader/scripts/mt_to_es.py
@@ -192,6 +192,21 @@ class ElasticsearchClient:
                 # this is used in seqr-loading-pipelines, but not writing these would
                 # result in a much smaller index
                 'es.spark.dataframe.write.null': 'true',
+                # --- connection robustness for long WAN exports to Elastic Cloud ---
+                # Elastic Cloud sits behind a proxy/LB that drops long or idle
+                # connections. On defaults (1m timeout, 3 retries) a transient blip
+                # over a multi-hour export throws EsHadoopNoNodesLeftException and,
+                # because Spark local mode does not retry tasks, aborts everything.
+                # These settings let each partition ride out network interruptions.
+                'es.http.timeout': '5m',  # per-request HTTP timeout (default 1m)
+                'es.http.retries': '10',  # retries per broken HTTP connection (default 3)
+                'es.batch.write.retry.count': '-1',  # retry bulk writes indefinitely (default 3)
+                'es.batch.write.retry.wait': '30s',  # backoff between bulk retries (default 10s)
+                # We already set index.refresh_interval=-1 on the mapping and
+                # forcemerge at the end, so the connector's per-partition refresh
+                # at task close is a redundant network round-trip and a common
+                # point of failure. Skip it.
+                'es.batch.write.refresh': 'false',
                 # We are not explicitly indexing the ES Index on varianId at this time
                 # we should probably investigate this in future, but if we index on variantId
                 # we run into the possibility that gCNV (currently multiple separate indices)


### PR DESCRIPTION
# Purpose

  - Add more retry logic to ES export to stop it failing, especially for large exports. E.g. https://batch.hail.populationgenomics.org.au/batches/1134548/jobs/1

## Problem

1. The connector is running on defaults tuned for a LAN, not a WAN to Elastic Cloud. The defaults are `es.http.timeout=1m`, `es.http.retries=3`, `es.batch.write.retry.count=3`, `es.batch.write.retry.wait=10s`. Elastic Cloud sits behind a load balancer/proxy (the LB) that will drop long or idle connections. When a transient blip outlasts those small retry budgets, the connector throws `EsHadoopNoNodesLeftException ("all nodes failed")`.
2. Spark local mode does not retry failed tasks. In the above batch job log, notice Task 89 in stage 0.0 failed 1 times. In `local[N]` mode `spark.task.maxFailures` defaults to 1, so a single partition failure anywhere in the job aborts the whole export with no retry. One dropped connection out of 124 partitions = start over.
3. The specific failure point is the per-partition refresh at task close. Your stack trace ends in `BulkProcessor.close() → RestClient.refresh()`. The connector issues an index refresh per partition as each task finishes. You've already set `index.refresh_interval=-1` in the mapping and do a forcemerge at the end, so those per-partition refresh calls are pure network round-trips you don't need and each one is a chance to hit the LB blip.

## Proposed Changes

  - Update es config with four robustness settings plus disabled redundant refresh:
 ```
┌────────────────────────────┬──────────────┬───────┬──────────────────────────────────────────────────┐
│          Setting           │     Old      │  New  │                            Why                   │
│                            │  (default)   │       │                                                  │
├────────────────────────────┼──────────────┼───────┼──────────────────────────────────────────────────┤
│ es.http.timeout            │ 1m           │ 5m    │ Survive slow LB responses on large bulk requests │
├────────────────────────────┼──────────────┼───────┼──────────────────────────────────────────────────┤
│ es.http.retries            │ 3            │ 10    │ Governs the refresh() call that fails            │
├────────────────────────────┼──────────────┼───────┼──────────────────────────────────────────────────┤
│ es.batch.write.retry.count │ 3            │ -1    │ Retry bulk writes indefinitely through outages   │
├────────────────────────────┼──────────────┼───────┼──────────────────────────────────────────────────┤
│ es.batch.write.retry.wait  │ 10s          │ 30s   │ Back off longer between retries                  │
├────────────────────────────┼──────────────┼───────┼──────────────────────────────────────────────────┤
│ es.batch.write.refresh     │ true         │ false │ Removes the per-partition refresh                │
└────────────────────────────┴──────────────┴───────┴──────────────────────────────────────────────────┘
```
  -

## Checklist

- [ ] Version Bump!
- [ ] Related GitHub Issue created
- [ ] Tests covering new change
- [ ] Linting checks pass
