### PR TITLE
Pipe 'yes' to job submission

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM australia-southeast1-docker.pkg.dev/cpg-common/images/cpg_hail_gcloud:0.2.138.cpg1-1
 
 ENV PYTHONDONTWRITEBYTECODE=1
-ENV VERSION=0.3.1
+ENV VERSION=0.3.2
 
 WORKDIR /cpg_seqr_loader
 

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ CPG-Flow workflows are operated entirely by defining input Cohorts (see [here](h
 ```bash
 analysis-runner \
     --skip-repo-checkout \
-    --image australia-southeast1-docker.pkg.dev/cpg-common/images/cpg-flow-seqr-loader:0.3.1-1 \
+    --image australia-southeast1-docker.pkg.dev/cpg-common/images/cpg-flow-seqr-loader:0.3.2-1 \
     --config src/cpg_seqr_loader/config_template.toml \
     --config cohorts.toml \  # containing the inputs_cohorts and sequencing_type
     --dataset seqr \
@@ -70,7 +70,7 @@ analysis-runner \
 ```bash
 analysis-runner \
     --skip-repo-checkout \
-    --image australia-southeast1-docker.pkg.dev/cpg-common/images/cpg-flow-seqr-loader:0.3.1-1 \
+    --image australia-southeast1-docker.pkg.dev/cpg-common/images/cpg-flow-seqr-loader:0.3.2-1 \
     --config src/cpg_seqr_loader/config_template.toml \
     --config cohorts.toml \  # containing the inputs_cohorts and sequencing_type
     --dataset seqr \

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ description='Seqr-Loader (gVCF-combiner) implemented in CPG-Flow'
 readme = "README.md"
 # currently cpg-flow is pinned to this version
 requires-python = ">=3.10,<3.12"
-version="0.3.1"
+version="0.3.2"
 license={"file" = "LICENSE"}
 classifiers=[
     'Environment :: Console',
@@ -108,7 +108,7 @@ hail = ["hail"]
 "src/cpg_seqr_loader/scripts/annotate_cohort.py" = ["E501"]
 
 [tool.bumpversion]
-current_version = "0.3.1"
+current_version = "0.3.2"
 parse = "(?P<major>\\d+)\\.(?P<minor>\\d+)\\.(?P<patch>\\d+)"
 serialize = ["{major}.{minor}.{patch}"]
 commit = true

--- a/src/cpg_seqr_loader/jobs/ResubmitWorkflow.py
+++ b/src/cpg_seqr_loader/jobs/ResubmitWorkflow.py
@@ -3,45 +3,13 @@ from typing import TYPE_CHECKING
 from cpg_utils import config, hail_batch
 
 if TYPE_CHECKING:
-    from hailtop.batch.job import PythonJob
+    from hailtop.batch.job import BashJob
 
 
-def submission_python_job(output_path: str):
-    """"""
-    import toml
-    from analysis_runner.cli_analysisrunner import run_analysis_runner
-
-    from cpg_utils import config, to_path
-
-    # make sure the config is loaded
-    _ar = config.config_retrieve(['workflow', 'ar-guid'])
-
-    # pop off any workflow-unique attributes
-    config_dict = dict(config._config)  # noqa: SLF001
-    _ar = config_dict['workflow'].pop('ar-guid')
-
-    with open('config.toml', 'w') as config_file:
-        config_file.write(toml.dumps(config_dict))
-
-    run_analysis_runner(
-        dataset=config_dict['workflow']['dataset'],
-        image=config_dict['workflow']['driver_image'],
-        output_dir='',
-        script=['full_workflow'],
-        description='',
-        access_level=config_dict['workflow']['access_level'],
-        config=['config.toml'],
-        skip_repo_checkout=True,
-    )
-
-    with to_path(output_path).open('w') as output_file:
-        output_file.write(toml.dumps(config_dict))
-
-
-def resubmit_full_workflow(output_path: str) -> 'PythonJob':
+def resubmit_full_workflow(output_path: str) -> 'BashJob':
     """Chain the second phase of the workflow using analysis-runner."""
     batch_instance = hail_batch.get_batch()
-    npj = batch_instance.new_python_job('Submit second Seqr-Loader workflow phase.')
-    npj.image(config.config_retrieve(['workflow', 'driver_image']))
-    npj.call(submission_python_job, output_path)
-    return npj
+    job = batch_instance.new_bash_job('Submit second Seqr-Loader workflow phase.')
+    job.image(config.config_retrieve(['workflow', 'driver_image']))
+    job.command(f'yes | python -m cpg_seqr_loader.scripts.resubmit_workflow {output_path}')
+    return job

--- a/src/cpg_seqr_loader/scripts/resubmit_workflow.py
+++ b/src/cpg_seqr_loader/scripts/resubmit_workflow.py
@@ -1,0 +1,44 @@
+import toml
+from argparse import ArgumentParser
+
+from analysis_runner.cli_analysisrunner import run_analysis_runner
+from cpg_utils import config, to_path
+
+
+def submission_python_job(output_path: str):
+    """"""
+
+    # make sure the config is loaded
+    _ar = config.config_retrieve(['workflow', 'ar-guid'])
+
+    # pop off any workflow-unique attributes
+    config_dict = dict(config._config)  # noqa: SLF001
+    _ar = config_dict['workflow'].pop('ar-guid')
+
+    with open('config.toml', 'w') as config_file:
+        config_file.write(toml.dumps(config_dict))
+
+    run_analysis_runner(
+        dataset=config_dict['workflow']['dataset'],
+        image=config_dict['workflow']['driver_image'],
+        output_dir='',
+        script=['full_workflow'],
+        description='',
+        access_level=config_dict['workflow']['access_level'],
+        config=['config.toml'],
+        skip_repo_checkout=True,
+    )
+
+    with to_path(output_path).open('w') as output_file:
+        output_file.write(toml.dumps(config_dict))
+
+
+def parse_arguments():
+    parser = ArgumentParser()
+    parser.add_argument('--output', type=str, required=True)
+    return parser.parse_args()
+
+
+if __name__ == '__main__':
+    args = parse_arguments()
+    submission_python_job(args.output)


### PR DESCRIPTION
# Purpose

  - The current process, using a PythonJob to chain the two halves of this workflow, cannot succeed as analysis-runner requires a typed 'y' input to proceed

## Proposed Changes

  - Alternative fix at source: https://github.com/populationgenomics/analysis-runner/pull/763
  - This redrafts the PythonJob as a bash script, so the outer job can use the usual tricks to pipe a `yes` command to the submission script, passing the CLI check

## Preference

  - I would prefer we solved this at source in Analysis-runner instead of writing knotted code, but this remains an option, depending on reception to that alternative PR

## Checklist

- [x] Version Bump!
- [ ] Related GitHub Issue created
- [ ] Tests covering new change
- [x] Linting checks pass
