### PR TITLE
Correction to resubmit point

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM australia-southeast1-docker.pkg.dev/cpg-common/images/cpg_hail_gcloud:0.2.138.cpg1-1
 
 ENV PYTHONDONTWRITEBYTECODE=1
-ENV VERSION=0.3.1
+ENV VERSION=0.3.2
 
 WORKDIR /cpg_seqr_loader
 

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ CPG-Flow workflows are operated entirely by defining input Cohorts (see [here](h
 ```bash
 analysis-runner \
     --skip-repo-checkout \
-    --image australia-southeast1-docker.pkg.dev/cpg-common/images/cpg-flow-seqr-loader:0.3.1-1 \
+    --image australia-southeast1-docker.pkg.dev/cpg-common/images/cpg-flow-seqr-loader:0.3.2-1 \
     --config src/cpg_seqr_loader/config_template.toml \
     --config cohorts.toml \  # containing the inputs_cohorts and sequencing_type
     --dataset seqr \
@@ -70,7 +70,7 @@ analysis-runner \
 ```bash
 analysis-runner \
     --skip-repo-checkout \
-    --image australia-southeast1-docker.pkg.dev/cpg-common/images/cpg-flow-seqr-loader:0.3.1-1 \
+    --image australia-southeast1-docker.pkg.dev/cpg-common/images/cpg-flow-seqr-loader:0.3.2-1 \
     --config src/cpg_seqr_loader/config_template.toml \
     --config cohorts.toml \  # containing the inputs_cohorts and sequencing_type
     --dataset seqr \

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ description='Seqr-Loader (gVCF-combiner) implemented in CPG-Flow'
 readme = "README.md"
 # currently cpg-flow is pinned to this version
 requires-python = ">=3.10,<3.12"
-version="0.3.1"
+version="0.3.2"
 license={"file" = "LICENSE"}
 classifiers=[
     'Environment :: Console',
@@ -108,7 +108,7 @@ hail = ["hail"]
 "src/cpg_seqr_loader/scripts/annotate_cohort.py" = ["E501"]
 
 [tool.bumpversion]
-current_version = "0.3.1"
+current_version = "0.3.2"
 parse = "(?P<major>\\d+)\\.(?P<minor>\\d+)\\.(?P<patch>\\d+)"
 serialize = ["{major}.{minor}.{patch}"]
 commit = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ classifiers=[
 ]
 
 dependencies=[
-    'analysis-runner',
+    'analysis-runner>=3.3.0',
     'cpg-flow~=1.3',
     'elasticsearch==8.*',
 ]

--- a/src/cpg_seqr_loader/first_workflow.py
+++ b/src/cpg_seqr_loader/first_workflow.py
@@ -8,7 +8,7 @@ import argparse
 
 from cpg_flow import workflow
 
-from cpg_seqr_loader.stages import DeleteCombinerTemp, SubmitPostCombinerWorkflow
+from cpg_seqr_loader.stages import CreateDenseMtFromVdsWithHail, SubmitPostCombinerWorkflow
 
 
 def cli_main():
@@ -18,7 +18,7 @@ def cli_main():
 
     workflow.run_workflow(
         name='seqr_loader',
-        stages=[DeleteCombinerTemp, SubmitPostCombinerWorkflow],
+        stages=[CreateDenseMtFromVdsWithHail, SubmitPostCombinerWorkflow],
         dry_run=args.dry_run,
     )
 

--- a/src/cpg_seqr_loader/stages.py
+++ b/src/cpg_seqr_loader/stages.py
@@ -57,21 +57,6 @@ class CombineGvcfsIntoVds(stage.MultiCohortStage):
         return self.make_outputs(multicohort, data=outputs, jobs=job)
 
 
-@stage.stage(required_stages=[CombineGvcfsIntoVds])
-class SubmitPostCombinerWorkflow(stage.MultiCohortStage):
-    def expected_outputs(self, multicohort: targets.MultiCohort) -> dict[str, Path]:
-        return {
-            'resubmit': self.prefix / f'{multicohort.name}_resubmitted.toml',
-        }
-
-    def queue_jobs(self, multicohort: targets.MultiCohort, inputs: stage.StageInput) -> stage.StageOutput:
-        outputs = self.expected_outputs(multicohort)
-
-        job = resubmit_full_workflow(str(outputs['resubmit']))
-
-        return self.make_outputs(multicohort, data=outputs, jobs=job)
-
-
 @stage.stage(required_stages=CombineGvcfsIntoVds)
 class DeleteCombinerTemp(stage.MultiCohortStage):
     """
@@ -146,6 +131,21 @@ class CreateDenseMtFromVdsWithHail(stage.MultiCohortStage):
             job_attrs=self.get_job_attrs(multicohort),
         )
         return self.make_outputs(target=multicohort, data=outputs, jobs=job)
+
+
+@stage.stage(required_stages=[CreateDenseMtFromVdsWithHail])
+class SubmitPostCombinerWorkflow(stage.MultiCohortStage):
+    def expected_outputs(self, multicohort: targets.MultiCohort) -> dict[str, Path]:
+        return {
+            'resubmit': self.prefix / f'{multicohort.name}_resubmitted.toml',
+        }
+
+    def queue_jobs(self, multicohort: targets.MultiCohort, inputs: stage.StageInput) -> stage.StageOutput:
+        outputs = self.expected_outputs(multicohort)
+
+        job = resubmit_full_workflow(str(outputs['resubmit']))
+
+        return self.make_outputs(multicohort, data=outputs, jobs=job)
 
 
 @stage.stage(required_stages=[CreateDenseMtFromVdsWithHail])


### PR DESCRIPTION
n.b. this is still broken (see #60), but positions the break point correctly, so pushing as a separate PR. If https://github.com/populationgenomics/analysis-runner/pull/764 is merged in before this is accepted, #60 would be unnecessary.

# Purpose

  - The resubmission point must come after densification. The Densification step creates an unknown number of fragments, which can't be handled in Hail Batch, hence needing a workflow in two halves

Related to https://github.com/populationgenomics/analysis-runner/pull/764